### PR TITLE
Fix development of Bintray artifacts

### DIFF
--- a/buildSrc/src/main/java/Repositories.kt
+++ b/buildSrc/src/main/java/Repositories.kt
@@ -68,7 +68,7 @@ internal fun Project.addDevRepository() {
 fun Project.addBintrayRepository() {
   the<BintrayExtension>().apply {
     user = System.getenv("BINTRAY_USER")
-    key = System.getenv("BINTRAY_PASSWORD")
+    key = System.getenv("BINTRAY_KEY")
     publish = true
 
     with(pkg) {


### PR DESCRIPTION
The "password" terminology was used before because the old CI used it.
There is no preferences on the new Github Action, so now, we match the
Bintray's terminology: "key"

JIRA: EE-1164