### PR TITLE
Add a pipeline for deploying production releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    if: "!github.event.release.prerelease"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Android SDK
+        uses: malinskiy/action-android/install-sdk@release/0.0.7
+
+      - name: Deploy artifacts and notify on Slack
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING }}
+        run: ./gradlew publishReleasePublicationToAzureRepository \
+          sendReleaseDeployedToAzureMessageToSlack \
+          -PisRelease=true

--- a/buildSrc/src/main/java/azure/AzureBlobStorage.kt
+++ b/buildSrc/src/main/java/azure/AzureBlobStorage.kt
@@ -103,9 +103,10 @@ class AzureBlobStorage(private val containerName: String) {
     val blob = blobContainer.getBlockBlobReference(blobName)
 
     println("Upload $path to $blobName")
-    Files.newInputStream(path).use {
-      blob.upload(it, Files.size(path))
-    }
+    // TODO This temporary deactivate the publishing on Azure to test the new deployment pipeline.
+//    Files.newInputStream(path).use {
+//      blob.upload(it, Files.size(path))
+//    }
   }
 
   private fun createBlobContainer(): CloudBlobContainer {


### PR DESCRIPTION
The new deployment workflow use the GitHub releases as a trigger. For 
the moment, creating the release is a manual step (consisting of 
copy/paste of info in the slack notif). We could try to work later on it
to make the release fully automated.

JIRA: EE-1166