### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @criteo/publisher-sdk


### PR DESCRIPTION
Given https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners,
this automatically assign the team for reviews. Hence, we could easily
track the pending reviews via https://github.com/pulls.