### PR TITLE
Move in progress changes in a dedicated section of the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Version 3.7.1
+# Next version
 
 - Features
   - Provide legal privacy text for native in `CriteoNativeAd#getLegalText`

--- a/buildSrc/src/main/java/Slack.kt
+++ b/buildSrc/src/main/java/Slack.kt
@@ -63,6 +63,8 @@ private fun Project.addSlackDeploymentMessage(publication: MavenPublication, rep
           versionLinesStartWith("# Version")
 
           if (isSnapshot()) {
+            versionLinesStartWith("# Next version")
+
             // On snapshots, we show the changelog in a code block so we can copy/paste it.
             format {
               section {


### PR DESCRIPTION
This is to avoid having publisher looking at the changelog and expecting
features/bugs in a version that is not yet released.