### PR TITLE
Deploy the test app in a dedicated package on Bintray

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,3 @@
-import Deps.Criteo.Mediation.adMobAdapter
-import Deps.Criteo.Mediation.moPubAdapter
-
 /*
  *    Copyright 2020 Criteo
  *
@@ -16,6 +13,9 @@ import Deps.Criteo.Mediation.moPubAdapter
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
+import Deps.Criteo.Mediation.adMobAdapter
+import Deps.Criteo.Mediation.moPubAdapter
 
 plugins {
     id("com.android.application")
@@ -60,7 +60,14 @@ addPublication("Apk") {
     }
 }
 
-addBintrayRepository()
+addBintrayRepository {
+    // JCenter only accepts packages representing library with .jar or .aar
+    // The test app is not in this case. Hence, we push it on Bintray but in a dedicated package,
+    // that will not get sync with JCenter (as it is not needed).
+    with(pkg) {
+        name = "publisher-sdk-test-app"
+    }
+}
 
 dependencies {
     implementation(project(":publisher-sdk"))

--- a/buildSrc/src/main/java/Repositories.kt
+++ b/buildSrc/src/main/java/Repositories.kt
@@ -41,10 +41,6 @@ internal fun RepositoryHandler.addDefaultInputRepository() {
   maven {
     setUrl("https://s3.amazonaws.com/moat-sdk-builds")
   }
-  maven {
-    // TODO EE-1167: remove this once development artifacts are sync on jcenter
-    setUrl("https://dl.bintray.com/criteo/mobile")
-  }
 }
 
 /**

--- a/buildSrc/src/main/java/Repositories.kt
+++ b/buildSrc/src/main/java/Repositories.kt
@@ -65,7 +65,7 @@ internal fun Project.addDevRepository() {
   }
 }
 
-fun Project.addBintrayRepository() {
+fun Project.addBintrayRepository(configure: BintrayExtension.() -> Unit = {}) {
   the<BintrayExtension>().apply {
     user = System.getenv("BINTRAY_USER")
     key = System.getenv("BINTRAY_KEY")
@@ -90,6 +90,8 @@ fun Project.addBintrayRepository() {
       val publicationNames = publishing.publications.map { it.name }.toTypedArray()
       setPublications(*publicationNames)
     }
+
+    configure(this)
   }
 }
 


### PR DESCRIPTION
JCenter only accept packages representing library with .jar or .aar
The test app is not in this case, and there is no meaning to sync it on
JCenter anyway. Hence, we push it on Bintray but in a dedicated package.
So the SDK and the test utils can be sync with JCenter.

This also remove the declaration of the specific Bintray repo of Criteo.
As mediation adapters are now sync with JCenter, this is not needed
anymore.

JIRA: EE-1167