### PR TITLE
Deactivate some flaky tests

### DIFF
--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/CriteoInterstitialActivityTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/CriteoInterstitialActivityTest.java
@@ -106,6 +106,7 @@ public class CriteoInterstitialActivityTest {
     verifyNoMoreInteractions(listener);
   }
 
+  @Ignore("FIXME EE-1180: Test does not pass on Github Actions")
   @Test
   public void whenUserClickOnAd_GivenHtmlWithHandledDeepLink_RedirectUserAndNotifyListener() throws Exception {
     Activity activity = whenUserClickOnAd("criteo-test://dummy-ad-activity");

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
@@ -139,6 +139,7 @@ public class CsmFunctionalTest {
     }));
   }
 
+  @Ignore("FIXME EE-1180: Test does not pass on Github Actions")
   @Test
   public void givenConsumedExpiredBid_CallApiWithCsmOfConsumedExpiredBid() throws Exception {
     when(clock.getCurrentTimeInMillis()).thenReturn(0L);


### PR DESCRIPTION
Android tests were never run on CI before. Hence, it is expected to find
some flakyness in tests. Such flaky tests are first deactivated. We will
try later to fix them in EE-1180.