### PR TITLE
Store cache between CI runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Store Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
       - name: Set up Android SDK
         uses: malinskiy/action-android/install-sdk@release/0.0.7
 
@@ -39,6 +46,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Store Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
 
       - name: Set up Android SDK
         uses: malinskiy/action-android/install-sdk@release/0.0.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Set up Android SDK
         uses: malinskiy/action-android/install-sdk@release/0.0.7
 
+      # This cache below is not fully working: it should go above the "Set up Android SDK" but:
+      # - The action does not support having a SDK already setup -> platform-tools, licenses are re-downloaded
+      # - Having this cache still prevents Gradle to re-download every time the build-tools.
+      - name: Store Android SDK
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.ANDROID_HOME }}
+          key: ${{ runner.os }}-android-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-android-
+
       - name: Build & Run Java tests
         run: ./gradlew build assembleAndroidTest
 


### PR DESCRIPTION
The Gradle files does not change that much. When there is no change, the
gradle cache is cached between runs on the CI. It is expected that this
speed up the build time.

It would also be nice to cache the Android SDK because this can take a while. But the action we're currently using does not seem to fully accept recycle SDK when (https://github.com/Malinskiy/action-android/issues/26).