### PR TITLE
Fix release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,4 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
-        run: ./gradlew bintrayUpload \
-          sendReleaseDeployedToBintrayMessageToSlack \
-          -PisRelease=true
+        run: ./gradlew bintrayUpload sendReleaseDeployedToBintrayMessageToSlack -PisRelease=true


### PR DESCRIPTION
GitHub multiline command is still a mystery, gradle was complaining
about the task ' sendReleaseDeployedToBintrayMessageToSlack' and told
that maybe we meant 'sendReleaseDeployedToBintrayMessageToSlack' (note
the extra space at the beginning of the task name)