### PR TITLE
Stabilize CSM test about timeout network

### DIFF
--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
@@ -283,6 +283,7 @@ public class CsmFunctionalTest {
     waitForIdleState();
 
     // Timeout
+    mockedDependenciesRule.getCdbMock().simulatorSlowNetworkOnNextRequest();
     when(buildConfigWrapper.getNetworkTimeoutInMillis()).thenReturn(1);
     criteo.getBidResponse(TestAdUnits.INTERSTITIAL);
     waitForIdleState();

--- a/test-utils/src/main/java/com/criteo/publisher/mock/MockedDependenciesRule.java
+++ b/test-utils/src/main/java/com/criteo/publisher/mock/MockedDependenciesRule.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import android.app.Application;
 import android.os.Build.VERSION_CODES;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import com.criteo.publisher.CriteoUtil;
@@ -185,5 +186,13 @@ public class MockedDependenciesRule implements MethodRule {
     doReturn(false).when(remoteConfigResponse).getKillSwitch();
     doReturn(true).when(remoteConfigResponse).getCsmEnabled();
     doReturn(remoteConfigResponse).when(pubSdkApi).loadConfig(any());
+  }
+
+  @NonNull
+  public CdbMock getCdbMock() {
+    if (cdbMock == null) {
+      throw new IllegalStateException("CDB mock is only available while test is running");
+    }
+    return cdbMock;
   }
 }


### PR DESCRIPTION
The logcat shows that, even by setting a really small timeout threshold,
timeout are not always throws by the network layer. This may be due
because the CDB mock server is embedded and fast.

In order to stabilize, the test, in addition of the small timeout
threshold, the CBB mock server is also throttled.