### PR TITLE
Use fixed version for the upload-artifact GA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           access-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload JUnit report
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: junit-report
@@ -75,7 +75,7 @@ jobs:
           cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -skin 360x640
 
       - name: Upload logcat output
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: logcat
@@ -88,7 +88,7 @@ jobs:
           access-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload JUnit report
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: junit-report


### PR DESCRIPTION
This GA is now using "main" as default branch. Using the master one
yield this warning:

The "master" branch is no longer the default branch name for
actions/upload-artifact
Please pin to a specific version or use "main".

To stay out of any change a fixed version is used instead.