### PR TITLE
Add E2E tests on Profile ID

### DIFF
--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,12 +65,6 @@ public class CsmFunctionalTest {
 
   @Rule
   public MockedDependenciesRule mockedDependenciesRule = new MockedDependenciesRule();
-
-  @Inject
-  private MetricSendingQueue queue;
-
-  @Inject
-  private MetricRepository repository;
 
   @Inject
   private IntegrationRegistry integrationRegistry;
@@ -89,14 +82,7 @@ public class CsmFunctionalTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     mockedDependenciesRule.givenMockedRemoteConfigResponse(api);
-    cleanState();
-
     integrationRegistry.declare(Integration.IN_HOUSE);
-  }
-
-  @After
-  public void tearDown() throws Exception {
-    cleanState();
   }
 
   @Test
@@ -411,15 +397,5 @@ public class CsmFunctionalTest {
 
   private void waitForIdleState() {
     mockedDependenciesRule.waitForIdleState();
-  }
-
-  private void cleanState() {
-    // Empty metric repository
-    for (Metric metric : repository.getAllStoredMetrics()) {
-      repository.moveById(metric.getImpressionId(), ignored -> true);
-    }
-
-    // Empty sending queue
-    queue.poll(Integer.MAX_VALUE);
   }
 }

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
@@ -64,4 +64,30 @@ class ProfileIdFunctionalTest {
     }, any())
   }
 
+  @Test
+  fun remoteConfig_GivenSdkUsedForTheFirstTime_UseFallbackProfileId() {
+    givenInitializedCriteo()
+    mockedDependenciesRule.waitForIdleState()
+
+    verify(api).loadConfig(check {
+      assertThat(it.profileId).isEqualTo(Integration.FALLBACK.profileId)
+    })
+  }
+
+  @Test
+  fun remoteConfig_GivenUsedSdk_UseLastProfileId() {
+    givenInitializedCriteo()
+    Criteo.getInstance().getBidResponse(BANNER_320_480)
+    mockedDependenciesRule.waitForIdleState()
+
+    mockedDependenciesRule.resetAllDependencies()
+
+    givenInitializedCriteo()
+    mockedDependenciesRule.waitForIdleState()
+
+    verify(api).loadConfig(check {
+      assertThat(it.profileId).isEqualTo(Integration.IN_HOUSE.profileId)
+    })
+  }
+
 }

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
@@ -1,0 +1,67 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher.integration
+
+import com.criteo.publisher.Criteo
+import com.criteo.publisher.CriteoUtil.givenInitializedCriteo
+import com.criteo.publisher.TestAdUnits.BANNER_320_480
+import com.criteo.publisher.mock.MockedDependenciesRule
+import com.criteo.publisher.mock.SpyBean
+import com.criteo.publisher.network.PubSdkApi
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class ProfileIdFunctionalTest {
+
+  @Rule
+  @JvmField
+  val mockedDependenciesRule = MockedDependenciesRule()
+
+  @SpyBean
+  private lateinit var api: PubSdkApi
+
+  @Test
+  fun prefetch_GivenSdkUsedForTheFirstTime_UseFallbackProfileId() {
+    givenInitializedCriteo(BANNER_320_480)
+    mockedDependenciesRule.waitForIdleState()
+
+    verify(api).loadCdb(check {
+      assertThat(it.profileId).isEqualTo(Integration.FALLBACK.profileId)
+    }, any())
+  }
+
+  @Test
+  fun prefetch_GivenUsedSdk_UseLatestProfileId() {
+    givenInitializedCriteo()
+    Criteo.getInstance().getBidResponse(BANNER_320_480)
+    mockedDependenciesRule.waitForIdleState()
+
+    mockedDependenciesRule.resetAllDependencies()
+
+    givenInitializedCriteo(BANNER_320_480)
+    mockedDependenciesRule.waitForIdleState()
+
+    verify(api).loadCdb(check {
+      assertThat(it.profileId).isEqualTo(Integration.IN_HOUSE.profileId)
+    }, any())
+  }
+
+}

--- a/test-utils/src/main/java/com/criteo/publisher/csm/MetricHelper.kt
+++ b/test-utils/src/main/java/com/criteo/publisher/csm/MetricHelper.kt
@@ -14,25 +14,26 @@
  *    limitations under the License.
  */
 
-package com.criteo.publisher.util;
+package com.criteo.publisher.csm
 
-import android.app.Application;
-import android.os.Build.VERSION;
-import androidx.test.core.app.ApplicationProvider;
-import com.criteo.publisher.mock.ApplicationMock;
+import android.os.Build
+import androidx.annotation.RequiresApi
+import com.criteo.publisher.DependencyProvider
 
-public class InstrumentationUtil {
+object MetricHelper {
 
-  public static boolean isRunningInInstrumentationTest() {
-    return VERSION.SDK_INT != 0;
-  }
-
-  public static Application getApplication() {
-    if (isRunningInInstrumentationTest()) {
-      return ApplicationProvider.getApplicationContext();
-    } else {
-      return ApplicationMock.newMock();
+  @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+  @JvmStatic
+  fun cleanState(dependencyProvider: DependencyProvider) {
+    // Empty metric repository
+    val repository = dependencyProvider.provideMetricRepository()
+    for (metric in repository.allStoredMetrics) {
+      repository.moveById(metric.impressionId) { true }
     }
+
+    // Empty sending queue
+    val queue = dependencyProvider.provideMetricSendingQueue()
+    queue.poll(Integer.MAX_VALUE)
   }
 
 }

--- a/test-utils/src/main/java/com/criteo/publisher/csm/MetricHelper.kt
+++ b/test-utils/src/main/java/com/criteo/publisher/csm/MetricHelper.kt
@@ -36,4 +36,10 @@ object MetricHelper {
     queue.poll(Integer.MAX_VALUE)
   }
 
+  val MetricRequest.internalProfileId: Int
+    get() = profileId
+
+  val MetricRequest.internalFeedbacks: List<MetricRequest.MetricRequestFeedback>
+    get() = feedbacks
+
 }

--- a/test-utils/src/main/java/com/criteo/publisher/mock/ApplicationMock.java
+++ b/test-utils/src/main/java/com/criteo/publisher/mock/ApplicationMock.java
@@ -28,10 +28,14 @@ import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 
 public class ApplicationMock {
 
-  @SuppressLint("CommitPrefEdits")
+  @SuppressLint({"CommitPrefEdits", "NewApi"})
   public static Application newMock() {
     // Explicitly mock shared preferences because it is a pain to handle them in unit tests.
     // This is more true for the getString one, because, since String class is final, it is
@@ -46,9 +50,18 @@ public class ApplicationMock {
     Editor editor = mock(Editor.class, RETURNS_DEEP_STUBS);
     when(sharedPreferences.edit()).thenReturn(editor);
 
+    // Used by CSM to store metric on filesystem
+    File filesDir;
+    try {
+      filesDir = Files.createTempDirectory(ApplicationMock.class.getName()).toFile();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
     Application application = mock(Application.class, RETURNS_DEEP_STUBS);
     when(application.getApplicationContext().getSharedPreferences(any(), anyInt()))
         .thenReturn(sharedPreferences);
+    when(application.getApplicationContext().getFilesDir()).thenReturn(filesDir);
     return application;
   }
 


### PR DESCRIPTION
# Tested scenarios:
## Prefetch done from unused SDK
- Given SDK used for the first time
- When initializing the SDK with ad units in prefetch
- And waiting for idle state
- Then CDB call is done with fallback profile ID

## Prefetch done from used SDK
- Given initialized SDK
- Given bid response fetched for InHouse (or any other integration)
- Given SDK rebooted (in-memory data is flush)
- When initializing the SDK with ad units in prefetch
- And waiting for idle state
- Then CDB call is done with InHouse (or other) profile ID

## Remote config done from unused SDK
- Given SDK used for the first time
- When initializing the SDK
- And waiting for idle state
- Then remote config call is done with fallback profile ID

## Remote config done from used SDK
- Given initialized SDK
- Given bid response fetched for InHouse (or any other integration)
- Given SDK rebooted (in-memory data is flush)
- When initializing the SDK
- And waiting for idle state
- Then remote config call is done with InHouse (or other) profile ID

## CSM yield from prefetch done from unused SDK
- Given SDK used for the first time
- Given initialized the SDK with an add prefetched
- When CSM request is triggered
- And waiting for idle state
- Then CSM call is done with fallback profile ID

## CSM yield from prefetch done from used SDK
- Given initialized SDK
- Given bid response fetched for InHouse (or any other integration)
- Given SDK rebooted (in-memory data is flush)
- Given initialized the SDK with an add prefetched
- When CSM request is triggered
- And waiting for idle state
- Then CSM call is done with InHouse (or other) profile ID

## CSM yield from bid done from unused SDK
- Given SDK used for the first time
- Given bid response fetched for InHouse (or any other integration)
- When CSM request is triggered
- And waiting for idle state
- Then CSM call is done with InHouse (or other) profile ID

## CSM yield from bid done from used SDK by another integration
- Given initialized SDK
- Given bid fetched for InHouse
- And waiting for idle state
- Given bid fetched for Custom AppBidding
- And waiting for idle state
- When CSM request is triggered
- And waiting for idle state
- Then 2 CSM calls are done with first then second profile ID

## Bid consumed from any state of the SDK

For all entry points of all integrations:
- Standalone:
  - `CriteoBannerView#loadAd`
  - `CriteoInterstitial#loadAd`
  - `CriteoNativeLoader#loadAd`
- InHouse: `Criteo#getBidResponse(AdUnit)`
- Custom AppBidding: `Criteo#setBidsForAdUnit(? < Map, AdUnit)`
- GAM AppBidding: `Criteo#setBidsForAdUnit(? < PublisherAdRequest.Builder, AdUnit)`
- MoPub AppBidding: `Criteo#setBidsForAdUnit(? < MoPubView | MoPubInterstitial, AdUnit)`

Then

- Given initialized SDK
- Given bid response fetched for any integration
- When getting bid response via integration entry point
- And waiting for idle state
- Then CDB call is done with integration profile ID

JIRA: EE-1205