### PR TITLE
Setup Gordon Gradle plugin to retry failing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           api: 29
           tag: google_apis
-          cmd: ./gradlew :publisher-sdk-tests:connectedCheck --info
+          cmd: ./gradlew :publisher-sdk-tests:gordon
           # Use a medium size skin rather than default size. Some tests need to have a decent size.
           cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -skin 360x640
 
@@ -86,13 +86,14 @@ jobs:
         if: failure()
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
+          path: "**/build/test-results/**/*.xml"
 
       - name: Upload JUnit report
         uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: junit-report
-          path: "**/build/reports/androidTests"
+          path: "**/build/reports"
 
   deploy-development-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,12 +65,27 @@ jobs:
       - name: Set up Android SDK
         uses: malinskiy/action-android/install-sdk@release/0.0.7
 
-      - name: Run Android tests
+      # Run all tests on merge
+      - name: Run all Android tests
         uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
+        if: github.event_name != 'pull_request'
         with:
           api: 29
           tag: google_apis
           cmd: ./gradlew :publisher-sdk-tests:gordon
+          # Use a medium size skin rather than default size. Some tests need to have a decent size.
+          cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -skin 360x640
+
+      # Run deterministic tests on PR
+      - name: Run Android tests w/o @FlakyTest
+        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
+        if: github.event_name == 'pull_request'
+        with:
+          api: 29
+          tag: google_apis
+          cmd: >
+            ./gradlew :publisher-sdk-tests:connectedCheck
+            -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.FlakyTest
           # Use a medium size skin rather than default size. Some tests need to have a decent size.
           cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -skin 360x640
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -140,18 +140,6 @@
       android:name=".MopubActivity"
       android:configChanges="orientation|screenSize"
       android:theme="@style/AppTheme"/>
-    <activity
-      android:configChanges="keyboardHidden|orientation|screenSize"
-      android:name="com.mopub.common.MoPubBrowser"/>
-    <activity
-      android:configChanges="keyboardHidden|orientation|screenSize"
-      android:name="com.mopub.mobileads.MraidVideoPlayerActivity"/>
-    <activity
-      android:configChanges="keyboardHidden|orientation|screenSize"
-      android:name="com.mopub.mobileads.MoPubActivity"/>
-    <activity
-      android:configChanges="keyboardHidden|orientation|screenSize"
-      android:name="com.mopub.mobileads.MraidActivity"/>
 
   </application>
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -22,6 +22,7 @@ repositories {
   google()
   jcenter()
   gradlePluginPortal()
+  maven("https://www.jitpack.io")
 }
 
 dependencies {
@@ -29,4 +30,5 @@ dependencies {
   implementation("com.android.tools.build:gradle:3.6.1")
   implementation("gradle.plugin.fr.pturpin.slackpublish:slack-publish:0.2.0")
   implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5")
+  implementation("com.banno.gordon:gordon-plugin:1.4.2")
 }

--- a/buildSrc/src/main/java/Deps.kt
+++ b/buildSrc/src/main/java/Deps.kt
@@ -95,12 +95,6 @@ object Deps {
     const val EqualsVerifier = "nl.jqno.equalsverifier:equalsverifier:$version"
   }
 
-  object GitHub {
-    object Kevinmost {
-      const val JUnitRetryRule = "com.github.kevinmost:junit-retry-rule:cbdd972d7c"
-    }
-  }
-
   object Google {
     private const val version = "19.0.1"
 

--- a/publisher-sdk-tests/build.gradle.kts
+++ b/publisher-sdk-tests/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
   androidTestImplementation(Deps.AssertJ.AssertJ)
   androidTestImplementation(Deps.Square.Tape.Tape)
   androidTestImplementation(Deps.Google.AdMob)
-  androidTestImplementation(Deps.GitHub.Kevinmost.JUnitRetryRule)
 
   androidTestImplementation(Deps.MoPub.Banner) {
     isTransitive = true

--- a/publisher-sdk-tests/build.gradle.kts
+++ b/publisher-sdk-tests/build.gradle.kts
@@ -17,7 +17,10 @@
 plugins {
   id("com.android.library")
   kotlin("android")
+  id("com.banno.gordon")
 }
+
+gordon.retryQuota.set(5)
 
 androidLibModule()
 

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/CriteoInterstitialActivityTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/CriteoInterstitialActivityTest.java
@@ -44,8 +44,6 @@ import com.criteo.publisher.mock.SpyBean;
 import com.criteo.publisher.test.activity.DummyActivity;
 import com.criteo.publisher.view.WebViewClicker;
 import com.criteo.publisher.view.WebViewLookup;
-import com.kevinmost.junit_retry_rule.Retry;
-import com.kevinmost.junit_retry_rule.RetryRule;
 import java.util.Collection;
 import javax.inject.Inject;
 import org.junit.Before;
@@ -59,9 +57,6 @@ import org.mockito.junit.MockitoRule;
 
 
 public class CriteoInterstitialActivityTest {
-
-  @Rule
-  public final RetryRule retry = new RetryRule();
 
   @Rule
   public ActivityTestRule<DummyActivity> activityRule = new ActivityTestRule<>(DummyActivity.class);
@@ -112,7 +107,6 @@ public class CriteoInterstitialActivityTest {
   }
 
   @Test
-  @Retry(timeout = 2000)
   public void whenUserClickOnAd_GivenHtmlWithHandledDeepLink_RedirectUserAndNotifyListener() throws Exception {
     Activity activity = whenUserClickOnAd("criteo-test://dummy-ad-activity");
 

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/CriteoInterstitialActivityTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/CriteoInterstitialActivityTest.java
@@ -34,6 +34,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.webkit.WebView;
 import androidx.annotation.NonNull;
+import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitor;
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry;
@@ -97,6 +98,7 @@ public class CriteoInterstitialActivityTest {
   }
 
   @Test
+  @FlakyTest
   public void whenUserClickOnAd_GivenHtmlWithNotHandledDeepLink_DoNothing() throws Exception {
     // We assume that no application can handle such URL.
 
@@ -107,6 +109,7 @@ public class CriteoInterstitialActivityTest {
   }
 
   @Test
+  @FlakyTest
   public void whenUserClickOnAd_GivenHtmlWithHandledDeepLink_RedirectUserAndNotifyListener() throws Exception {
     Activity activity = whenUserClickOnAd("criteo-test://dummy-ad-activity");
 
@@ -117,6 +120,7 @@ public class CriteoInterstitialActivityTest {
   }
 
   @Test
+  @FlakyTest
   public void whenUserClickOnAdAndGoBack_GivenHtmlWithHandledDeepLink_NotifyListener() throws Exception {
     String html = clicker.getAdHtmlWithClickUrl("criteo-test://dummy-ad-activity");
     CriteoInterstitialActivity activity = givenOpenedInterstitialActivity(html);

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/activity/TopActivityFinderTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/activity/TopActivityFinderTest.java
@@ -29,16 +29,11 @@ import com.criteo.publisher.concurrent.ThreadingUtil;
 import com.criteo.publisher.mock.MockedDependenciesRule;
 import com.criteo.publisher.test.activity.DummyActivity;
 import com.criteo.publisher.view.WebViewLookup;
-import com.kevinmost.junit_retry_rule.Retry;
-import com.kevinmost.junit_retry_rule.RetryRule;
 import javax.inject.Inject;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class TopActivityFinderTest {
-
-  @Rule
-  public RetryRule retryRule = new RetryRule();
 
   @Rule
   public MockedDependenciesRule mockedDependenciesRule = new MockedDependenciesRule();
@@ -79,7 +74,6 @@ public class TopActivityFinderTest {
   }
 
   @Test
-  @Retry(timeout = 3000)
   public void topActivityName_GivenFinishedActivityWithoutPredecessor_ReturnNull() throws Exception {
     givenInitializedCriteo();
     activityRule.launchActivity(new Intent());

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/activity/TopActivityFinderTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/activity/TopActivityFinderTest.java
@@ -24,6 +24,7 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.concurrent.ThreadingUtil;
 import com.criteo.publisher.mock.MockedDependenciesRule;
@@ -74,6 +75,7 @@ public class TopActivityFinderTest {
   }
 
   @Test
+  @FlakyTest(detail = "Flakiness comes from UI and concurrency")
   public void topActivityName_GivenFinishedActivityWithoutPredecessor_ReturnNull() throws Exception {
     givenInitializedCriteo();
     activityRule.launchActivity(new Intent());

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/advancednative/AdChoiceOverlayTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/advancednative/AdChoiceOverlayTest.java
@@ -54,7 +54,11 @@ public class AdChoiceOverlayTest {
   public MockedDependenciesRule mockedDependenciesRule = new MockedDependenciesRule();
 
   @SuppressWarnings("rawtypes")
-  @Parameterized.Parameters(name = "{index}: {0}")
+  // FIXME Gordon runner does not support named parameterized test => they appear as IGNORED.
+  //  Issue come from Android tools not supporting this neither.
+  //  See https://github.com/Banno/Gordon/issues/47
+  // @Parameterized.Parameters(name = "{index}: {0}")
+  @Parameterized.Parameters
   public static Collection consents() {
     return Arrays.asList(new Object[][]{
         { new SimpleViewFactory() },

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/advancednative/VisibilityCheckerTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/advancednative/VisibilityCheckerTest.java
@@ -27,17 +27,12 @@ import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.test.activity.DummyActivity;
-import com.kevinmost.junit_retry_rule.Retry;
-import com.kevinmost.junit_retry_rule.RetryRule;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
 public class VisibilityCheckerTest {
-
-  @Rule
-  public final RetryRule retry = new RetryRule();
 
   @Rule
   public ActivityTestRule<DummyActivity> activityRule = new ActivityTestRule<>(DummyActivity.class);
@@ -104,7 +99,6 @@ public class VisibilityCheckerTest {
   }
 
   @Test
-  @Retry(timeout = 2000)
   public void isVisible_GivenViewInScrollView_ReturnAccordinglyToScrolling() throws Exception {
     int screenHeightPixels = uiHelper.getActivityHeightPixels();
     int viewHeightPixels = 200;

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/advancednative/VisibilityCheckerTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/advancednative/VisibilityCheckerTest.java
@@ -25,6 +25,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
 import android.widget.ScrollView;
+import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.test.activity.DummyActivity;
 import org.junit.Before;
@@ -99,6 +100,7 @@ public class VisibilityCheckerTest {
   }
 
   @Test
+  @FlakyTest(detail = "Flakiness comes from UI + concurrency")
   public void isVisible_GivenViewInScrollView_ReturnAccordinglyToScrolling() throws Exception {
     int screenHeightPixels = uiHelper.getActivityHeightPixels();
     int viewHeightPixels = 200;

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
@@ -43,8 +43,6 @@ import com.criteo.publisher.mock.MockedDependenciesRule;
 import com.criteo.publisher.mock.SpyBean;
 import com.criteo.publisher.network.PubSdkApi;
 import com.criteo.publisher.util.BuildConfigWrapper;
-import com.kevinmost.junit_retry_rule.Retry;
-import com.kevinmost.junit_retry_rule.RetryRule;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,9 +57,6 @@ import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
 public class CsmFunctionalTest {
-
-  @Rule
-  public final RetryRule retry = new RetryRule();
 
   @Rule
   public MockedDependenciesRule mockedDependenciesRule = new MockedDependenciesRule();
@@ -86,7 +81,6 @@ public class CsmFunctionalTest {
   }
 
   @Test
-  @Retry
   public void givenPrefetchAdUnitsWithBidsThenConsumption_CallApiWithCsmOfConsumedBid() throws Exception {
     givenInitializedCriteo(TestAdUnits.BANNER_320_50, TestAdUnits.INTERSTITIAL);
     waitForIdleState();
@@ -138,7 +132,6 @@ public class CsmFunctionalTest {
   }
 
   @Test
-  @Retry
   public void givenConsumedExpiredBid_CallApiWithCsmOfConsumedExpiredBid() throws Exception {
     when(clock.getCurrentTimeInMillis()).thenReturn(0L);
     givenInitializedCriteo(TestAdUnits.BANNER_320_50, TestAdUnits.INTERSTITIAL);
@@ -168,7 +161,6 @@ public class CsmFunctionalTest {
   }
 
   @Test
-  @Retry
   public void givenNoBidFromCdb_CallApiWithCsmOfNoBid() throws Exception {
     givenInitializedCriteo(TestAdUnits.BANNER_320_50, TestAdUnits.INTERSTITIAL_UNKNOWN);
     waitForIdleState();
@@ -188,7 +180,6 @@ public class CsmFunctionalTest {
   }
 
   @Test
-  @Retry
   public void givenNetworkErrorFromCdb_CallApiWithCsmOfNetworkError() throws Exception {
     doThrow(IOException.class).when(api).loadCdb(any(), any());
 
@@ -219,7 +210,6 @@ public class CsmFunctionalTest {
   }
 
   @Test
-  @Retry
   public void givenTimeoutErrorFromCdb_CallApiWithCsmOfTimeoutError() throws Exception {
     when(buildConfigWrapper.getNetworkTimeoutInMillis()).thenReturn(1);
 
@@ -252,7 +242,6 @@ public class CsmFunctionalTest {
   }
 
   @Test
-  @Retry
   public void givenErrorWhenSendingCsm_QueueMetricsUntilCsmRequestWorksAgain() throws Exception {
     when(buildConfigWrapper.preconditionThrowsOnException()).thenReturn(false);
     doThrow(IOException.class).when(api).postCsm(any());

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import androidx.core.util.Consumer;
+import androidx.test.filters.FlakyTest;
 import com.criteo.publisher.Clock;
 import com.criteo.publisher.Criteo;
 import com.criteo.publisher.TestAdUnits;
@@ -56,6 +57,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
+@FlakyTest(detail = "CSM are triggered concurrently of bid")
 public class CsmFunctionalTest {
 
   @Rule

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/CriteoFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/CriteoFunctionalTest.java
@@ -47,8 +47,6 @@ import com.criteo.publisher.model.InterstitialAdUnit;
 import com.criteo.publisher.network.PubSdkApi;
 import com.criteo.publisher.test.activity.DummyActivity;
 import com.criteo.publisher.util.BuildConfigWrapper;
-import com.kevinmost.junit_retry_rule.Retry;
-import com.kevinmost.junit_retry_rule.RetryRule;
 import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
@@ -58,9 +56,6 @@ import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
 public class CriteoFunctionalTest {
-
-  @Rule
-  public final RetryRule retry = new RetryRule();
 
   @Rule
   public MockedDependenciesRule mockedDependenciesRule = new MockedDependenciesRule();
@@ -130,7 +125,6 @@ public class CriteoFunctionalTest {
   }
 
   @Test
-  @Retry(timeout = 2000)
   public void init_GivenPrefetchAdUnitAndLaunchedActivity_CallConfigAndCdbAndBearcat()
       throws Exception {
     givenInitializedCriteo(validBannerAdUnit);

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/CriteoFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/CriteoFunctionalTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import android.app.Application;
 import android.content.Intent;
 import android.os.Looper;
+import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.BidManager;
 import com.criteo.publisher.Criteo;
@@ -125,6 +126,7 @@ public class CriteoFunctionalTest {
   }
 
   @Test
+  @FlakyTest
   public void init_GivenPrefetchAdUnitAndLaunchedActivity_CallConfigAndCdbAndBearcat()
       throws Exception {
     givenInitializedCriteo(validBannerAdUnit);

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/DfpHeaderBiddingFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/DfpHeaderBiddingFunctionalTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 import android.os.Bundle;
 import android.view.View;
+import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.Criteo;
 import com.criteo.publisher.TestAdUnits;
@@ -74,6 +75,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 
+@FlakyTest(detail = "DFP network is flaky")
 public class DfpHeaderBiddingFunctionalTest {
 
   private static final String MACRO_CPM = "crt_cpm";

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
@@ -43,6 +43,7 @@ import android.content.res.Configuration;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
+import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.CriteoBannerAdListener;
 import com.criteo.publisher.CriteoBannerView;
@@ -130,6 +131,7 @@ public class StandaloneFunctionalTest {
   }
 
   @Test
+  @FlakyTest
   public void whenLoadingAnInterstitial_GivenBidAvailableAndDeviceInPortrait_DisplayUrlIsProperlyLoadedInInterstitialActivity()
       throws Exception {
     givenDeviceInPortrait();
@@ -137,6 +139,7 @@ public class StandaloneFunctionalTest {
   }
 
   @Test
+  @FlakyTest
   public void whenLoadingAnInterstitial_GivenBidAvailableAndDeviceInLandscape_DisplayUrlIsProperlyLoadedInInterstitialActivity()
       throws Exception {
     givenDeviceInLandscape();
@@ -156,6 +159,7 @@ public class StandaloneFunctionalTest {
   }
 
   @Test
+  @FlakyTest
   public void whenLoadingAnInterstitial_GivenBidAvailableTwice_DisplayUrlIsProperlyLoadedInInterstitialActivityTwice()
       throws Exception {
     givenInitializedSdk(validInterstitialAdUnit);

--- a/publisher-sdk-tests/src/main/AndroidManifest.xml
+++ b/publisher-sdk-tests/src/main/AndroidManifest.xml
@@ -41,10 +41,6 @@
         <data android:scheme="criteo-test" android:host="dummy-ad-activity" />
       </intent-filter>
     </activity>
-
-    <activity
-      android:configChanges="keyboardHidden|orientation|screenSize"
-      android:name="com.mopub.mobileads.MoPubActivity"/>
   </application>
 
 </manifest>


### PR DESCRIPTION
This will retry failing tests up to 3 times. This plugin wrap the
connected Android tests and its main features are:
- Retrying failing tests
- Generating JUnit XML reports (with syserr for recovered flaky tests)
- Generating HTML reports with failing/recovering/passing tests
- Printing ongoing tests in stdout without --info on Gradle logger

Why do we need it ?
Because your tests are so flaky that the devs have to use Head&Shoulders
dandruff shampoo</Gordon Ramsay>