### PR TITLE
Setup Marathon Gradle plugin to retry failing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           api: 29
           tag: google_apis
-          cmd: ./gradlew :publisher-sdk-tests:connectedCheck --info
+          cmd: ./gradlew :publisher-sdk-tests:marathonDebugAndroidTest --info
           # Use a medium size skin rather than default size. Some tests need to have a decent size.
           cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -skin 360x640
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -29,4 +29,5 @@ dependencies {
   implementation("com.android.tools.build:gradle:3.6.1")
   implementation("gradle.plugin.fr.pturpin.slackpublish:slack-publish:0.2.0")
   implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5")
+  implementation("com.malinskiy.marathon:marathon-gradle-plugin:0.5.2")
 }

--- a/publisher-sdk-tests/build.gradle.kts
+++ b/publisher-sdk-tests/build.gradle.kts
@@ -17,6 +17,21 @@
 plugins {
   id("com.android.library")
   kotlin("android")
+  id("marathon")
+}
+
+marathon {
+  batchingStrategy {
+    fixedSize {
+      size = 10
+    }
+  }
+  retryStrategy {
+    fixedQuota {
+      totalAllowedRetryQuota = 200
+      retryPerTestQuota = 3
+    }
+  }
 }
 
 androidLibModule()


### PR DESCRIPTION
This will retry failing tests up to 3 times. This plugin wrap the
connected Android tests and its main features are:
- Retrying failing tests