### PR TITLE
Handle subclasses of MoPub objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Next version
 
+- Features
+  - MoPub Header-Bidding: Handle subclasses of `MoPubView` and `MoPubInterstitial`
+
 # Version 3.9.0
 
 - Features

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/headerbidding/MoPubHeaderBiddingTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/headerbidding/MoPubHeaderBiddingTest.java
@@ -69,8 +69,29 @@ public class MoPubHeaderBiddingTest {
   }
 
   @Test
+  public void canHandle_GivenSubClassOfMoPubView_ReturnTrue() throws Exception {
+    MoPubView moPub = callOnMainThreadAndWait(() -> new MoPubView(activityRule.getActivity()) {
+    });
+
+    boolean handling = headerBidding.canHandle(moPub);
+
+    assertTrue(handling);
+  }
+
+  @Test
   public void canHandle_GivenMoPubInterstitial_ReturnTrue() throws Exception {
     MoPubInterstitial moPub = givenMoPubInterstitial();
+
+    boolean handling = headerBidding.canHandle(moPub);
+
+    assertTrue(handling);
+  }
+
+  @Test
+  public void canHandle_GivenSubClassOfMoPubInterstitial_ReturnTrue() throws Exception {
+    MoPubInterstitial moPub = callOnMainThreadAndWait(() ->
+        new MoPubInterstitial(activityRule.getActivity(), "adUnit") {
+        });
 
     boolean handling = headerBidding.canHandle(moPub);
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/headerbidding/MoPubHeaderBidding.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/headerbidding/MoPubHeaderBidding.java
@@ -16,6 +16,8 @@
 
 package com.criteo.publisher.headerbidding;
 
+import static com.criteo.publisher.util.ReflectionUtil.isInstanceOf;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.criteo.publisher.integration.Integration;
@@ -43,8 +45,8 @@ public class MoPubHeaderBidding implements HeaderBiddingHandler {
   );
 
   public boolean canHandle(@NonNull Object object) {
-    return object.getClass().getName().equals(MOPUB_ADVIEW_CLASS)
-        || object.getClass().getName().equals(MOPUB_INTERSTITIAL_CLASS);
+    return isInstanceOf(object, MOPUB_ADVIEW_CLASS)
+        || isInstanceOf(object, MOPUB_INTERSTITIAL_CLASS);
   }
 
   @NonNull

--- a/publisher-sdk/src/main/java/com/criteo/publisher/util/ReflectionUtil.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/util/ReflectionUtil.java
@@ -28,6 +28,17 @@ public class ReflectionUtil {
   @NonNull
   private static final Logger logger = LoggerFactory.getLogger(ReflectionUtil.class);
 
+  public static boolean isInstanceOf(@NonNull Object object, @NonNull String className) {
+    try {
+      ClassLoader classLoader = ReflectionUtil.class.getClassLoader();
+      Class<?> klass = Class.forName(className, false, classLoader);
+      return klass.isAssignableFrom(object.getClass());
+    } catch (ClassNotFoundException | LinkageError e) {
+      logger.debug("Failed to load class by name to check if instanceof", e);
+      return false;
+    }
+  }
+
   @Nullable
   public static Object callMethodOnObject(
       @NonNull Object object,


### PR DESCRIPTION
On Android header bidding integrations, we check the class name to decide the integration type and properly insert keywords by using string equality, e.g. "MoPubView" / "MoPubInterstitial" for MoPub.

Some publishers may extend these classes and use subclasses of GAM / MoPub objects, currently we can't set keywords with these subclasses.

We'd like to support both the original MoPub objects and their subclasses.

JIRA: EE-1113