### PR TITLE
Hide Git block in Slack notif on public release

### DIFF
--- a/buildSrc/src/main/java/Slack.kt
+++ b/buildSrc/src/main/java/Slack.kt
@@ -55,7 +55,9 @@ private fun Project.addSlackDeploymentMessage(publication: MavenPublication) {
           repositoryName.set(repoName)
         }
 
-        git()
+        if (isSnapshot()) {
+          git()
+        }
 
         changelog {
           version.set(sdkVersion())


### PR DESCRIPTION
This block is not really helpful for public release.