### PR TITLE
Only prefetch once every 30 secs

### DIFF
--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
@@ -17,6 +17,7 @@
 package com.criteo.publisher.integration
 
 import android.content.Context
+import com.criteo.publisher.BidPrefetchRateLimiter
 import com.criteo.publisher.Criteo
 import com.criteo.publisher.CriteoBannerView
 import com.criteo.publisher.CriteoInterstitial
@@ -26,6 +27,7 @@ import com.criteo.publisher.advancednative.CriteoNativeLoader
 import com.criteo.publisher.concurrent.ThreadingUtil.runOnMainThreadAndWait
 import com.criteo.publisher.csm.MetricHelper
 import com.criteo.publisher.csm.MetricSendingQueueConsumer
+import com.criteo.publisher.mock.MockBean
 import com.criteo.publisher.mock.MockedDependenciesRule
 import com.criteo.publisher.mock.SpyBean
 import com.criteo.publisher.network.PubSdkApi
@@ -34,6 +36,7 @@ import com.mopub.mobileads.MoPubInterstitial
 import com.mopub.mobileads.MoPubView
 import com.nhaarman.mockitokotlin2.*
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Inject
@@ -53,8 +56,12 @@ class ProfileIdFunctionalTest {
   @SpyBean
   private lateinit var api: PubSdkApi
 
+  @MockBean
+  private lateinit var bidPrefetchRateLimiter: BidPrefetchRateLimiter
+
   @Test
   fun prefetch_GivenSdkUsedForTheFirstTime_UseFallbackProfileId() {
+    whenever(bidPrefetchRateLimiter.canPrefetch()).thenReturn(true)
     givenInitializedCriteo(BANNER_320_480)
     mockedDependenciesRule.waitForIdleState()
 
@@ -73,6 +80,7 @@ class ProfileIdFunctionalTest {
 
   @Test
   fun remoteConfig_GivenSdkUsedForTheFirstTime_UseFallbackProfileId() {
+    whenever(bidPrefetchRateLimiter.canPrefetch()).thenReturn(true)
     givenInitializedCriteo()
     mockedDependenciesRule.waitForIdleState()
 
@@ -95,6 +103,7 @@ class ProfileIdFunctionalTest {
 
   @Test
   fun csm_GivenPrefetchWithSdkUsedForTheFirstTime_UseFallbackProfileId() {
+    whenever(bidPrefetchRateLimiter.canPrefetch()).thenReturn(true)
     givenInitializedCriteo(BANNER_320_480)
     mockedDependenciesRule.waitForIdleState()
 
@@ -109,6 +118,7 @@ class ProfileIdFunctionalTest {
 
   @Test
   fun csm_GivenPrefetchWithUsedSdk_UseLatestProfileId() {
+    whenever(bidPrefetchRateLimiter.canPrefetch()).thenReturn(true)
     givenPreviousInHouseIntegration()
 
     // Clean the metric yields above to avoid interference
@@ -278,6 +288,7 @@ class ProfileIdFunctionalTest {
     Criteo.getInstance().getBidResponse(BANNER_320_480)
     mockedDependenciesRule.waitForIdleState()
     mockedDependenciesRule.resetAllDependencies()
+    whenever(bidPrefetchRateLimiter.canPrefetch()).thenReturn(true)
   }
 
   private fun triggerMetricRequest() {

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/model/ConfigIntegrationTests.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/model/ConfigIntegrationTests.java
@@ -331,7 +331,8 @@ public class ConfigIntegrationTests {
         "mode1",
         "macro2",
         "mode2",
-        false
+        false,
+        30_000L
     );
 
     givenRemoteConfigInLocalStorage(persistedConfig);
@@ -354,6 +355,7 @@ public class ConfigIntegrationTests {
         "mode1",
         null,
         "mode2",
+        null,
         null
     );
 
@@ -363,7 +365,8 @@ public class ConfigIntegrationTests {
         "overriddenMode1",
         "overriddenMacro2",
         null,
-        false
+        false,
+        null
     );
 
     RemoteConfigResponse expectedRemoteConfig = RemoteConfigResponse.create(
@@ -372,7 +375,8 @@ public class ConfigIntegrationTests {
         "overriddenMode1",
         "overriddenMacro2",
         "mode2",
-        false
+        false,
+        null
     );
 
     givenRemoteConfigInLocalStorage(oldPersistedConfig);

--- a/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/network/PubSdkApiIntegrationTest.java
+++ b/publisher-sdk-tests/src/androidTest/java/com/criteo/publisher/network/PubSdkApiIntegrationTest.java
@@ -35,6 +35,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
+import com.criteo.publisher.BidPrefetchRateLimiter;
 import com.criteo.publisher.StubConstants;
 import com.criteo.publisher.csm.MetricRequest;
 import com.criteo.publisher.mock.MockedDependenciesRule;
@@ -385,7 +386,8 @@ public class PubSdkApiIntegrationTest {
         "<html><body style='text-align:center; margin:0px; padding:0px; horizontal-align:center;'><script src=\"%%displayUrl%%\"></script></body></html>",
         "%%adTagData%%",
         "<html><body style='text-align:center; margin:0px; padding:0px; horizontal-align:center;'><script>%%adTagData%%</script></body></html>",
-        true
+        true,
+        null // FIXME: adjust once the remote config is added
     );
   }
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/BidPrefetchRateLimiter.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/BidPrefetchRateLimiter.kt
@@ -1,0 +1,58 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher
+
+import android.content.SharedPreferences
+import com.criteo.publisher.annotation.Internal
+import com.criteo.publisher.annotation.OpenForTesting
+import com.criteo.publisher.model.Config
+import com.criteo.publisher.util.SafeSharedPreferences
+
+/**
+ * This class guards against calling [BidManager.prefetch] many times in a short time span. This protects
+ * against apps with services that are re-spawned automatically (on boot, after process kill) which
+ * could cause too many initializations of [Criteo] in a short amount of time.
+ */
+@OpenForTesting
+@Internal
+class BidPrefetchRateLimiter(
+    private val clock: Clock,
+    private val sharedPreferences: SharedPreferences,
+    private val safeSharedPreferences: SafeSharedPreferences,
+    private val config: Config
+) {
+
+  companion object {
+    const val STORAGE_KEY = "LAST_PREFETCH_TIME"
+    const val UNSET_PREFETCH_TIME = -1L
+  }
+
+  fun canPrefetch(): Boolean {
+    val lastPrefetchTime: Long = safeSharedPreferences.getLong(STORAGE_KEY, UNSET_PREFETCH_TIME)
+    if (lastPrefetchTime == UNSET_PREFETCH_TIME ||
+        clock.currentTimeInMillis - lastPrefetchTime >= config.minTimeBetweenPrefetchesMillis) {
+      return true
+    }
+    return false
+  }
+
+  fun setPrefetchTime() {
+    val editor: SharedPreferences.Editor = sharedPreferences.edit()
+    editor.putLong(STORAGE_KEY, clock.currentTimeInMillis)
+    editor.apply()
+  }
+}

--- a/publisher-sdk/src/main/java/com/criteo/publisher/model/Config.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/model/Config.java
@@ -58,6 +58,7 @@ public class Config {
     private static final String AD_TAG_DATA_MACRO = "%%adTagData%%";
     private static final String AD_TAG_DATA_MODE = "<html><body style='text-align:center; margin:0px; padding:0px; horizontal-align:center;'><script>%%adTagData%%</script></body></html>";
     private static final boolean CSM_ENABLED = true;
+    private static final Long MIN_TIME_BETWEEN_BID_PREFETCHES_MILLIS = 30_000L;
 
   }
 
@@ -154,6 +155,10 @@ public class Config {
         getOrElse(
             overrideRemoteConfig.getCsmEnabled(),
             baseRemoteConfig.getCsmEnabled()
+        ),
+        getOrElse(
+            overrideRemoteConfig.getMinTimeBetweenBidPrefetchMillis(),
+            baseRemoteConfig.getMinTimeBetweenBidPrefetchMillis()
         )
     );
   }
@@ -234,6 +239,14 @@ public class Config {
     return getOrElse(
         cachedRemoteConfig.getAndroidAdTagDataMode(),
         DefaultConfig.AD_TAG_DATA_MODE
+    );
+  }
+
+  @NonNull
+  public Long getMinTimeBetweenPrefetchesMillis() {
+    return getOrElse(
+        cachedRemoteConfig.getMinTimeBetweenBidPrefetchMillis(),
+        DefaultConfig.MIN_TIME_BETWEEN_BID_PREFETCHES_MILLIS
     );
   }
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/model/RemoteConfigResponse.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/model/RemoteConfigResponse.java
@@ -33,7 +33,8 @@ public abstract class RemoteConfigResponse {
       @Nullable String androidAdTagUrlMode,
       @Nullable String androidAdTagDataMacro,
       @Nullable String androidAdTagDataMode,
-      @Nullable Boolean csmEnabled
+      @Nullable Boolean csmEnabled,
+      @Nullable Long minTimeBetweenBidPrefetchMillis
   ) {
     return new AutoValue_RemoteConfigResponse(
         killSwitch,
@@ -41,13 +42,15 @@ public abstract class RemoteConfigResponse {
         androidAdTagUrlMode,
         androidAdTagDataMacro,
         androidAdTagDataMode,
-        csmEnabled
+        csmEnabled,
+        minTimeBetweenBidPrefetchMillis
     );
   }
 
   @NonNull
   public static RemoteConfigResponse createEmpty() {
     return create(
+        null,
         null,
         null,
         null,
@@ -65,7 +68,8 @@ public abstract class RemoteConfigResponse {
         getAndroidAdTagUrlMode(),
         getAndroidAdTagDataMacro(),
         getAndroidAdTagDataMode(),
-        getCsmEnabled()
+        getCsmEnabled(),
+        getMinTimeBetweenBidPrefetchMillis()
     );
   }
 
@@ -144,4 +148,9 @@ public abstract class RemoteConfigResponse {
   @Nullable
   public abstract Boolean getCsmEnabled();
 
+  /**
+   * Minimum elapsed time between two bids prefetch calls.
+   */
+  @Nullable
+  public abstract Long getMinTimeBetweenBidPrefetchMillis();
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/util/SafeSharedPreferences.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/util/SafeSharedPreferences.java
@@ -62,6 +62,21 @@ public class SafeSharedPreferences {
     return value;
   }
 
+  public long getLong(@NonNull String key, long defaultValue) {
+    long value = defaultValue;
+
+    try {
+      value = sharedPreferences.getLong(key, defaultValue);
+    } catch (ClassCastException e) {
+      PreconditionsUtil.throwOrLog(
+          new IllegalStateException("Expect a Long type when reading " + key, e)
+      );
+    }
+
+    return value;
+  }
+
+
   public boolean getBoolean(@NonNull String key, boolean defaultValue) {
     boolean value = defaultValue;
 

--- a/publisher-sdk/src/test/java/com/criteo/publisher/BidManagerTests.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/BidManagerTests.java
@@ -91,6 +91,9 @@ public class BidManagerTests {
   @Mock
   private IntegrationRegistry integrationRegistry;
 
+  @Mock
+  private BidPrefetchRateLimiter bidPrefetchRateLimiter;
+
   @Before
   public void setup() {
     MockitoAnnotations.initMocks(this);
@@ -124,6 +127,8 @@ public class BidManagerTests {
 
     testSlot = CdbResponseSlot.fromJson(slotJson);
     when(this.sdkCache.peekAdUnit(cAdUnit)).thenReturn(testSlot);
+
+    when(bidPrefetchRateLimiter.canPrefetch()).thenReturn(true);
 
     DependencyProvider.setInstance(dependencyProvider);
   }
@@ -208,7 +213,8 @@ public class BidManagerTests {
         adUnitMapper,
         bidRequestSender,
         bidLifecycleListener,
-        metricSendingQueueConsumer
+        metricSendingQueueConsumer,
+        bidPrefetchRateLimiter
     );
   }
 

--- a/publisher-sdk/src/test/java/com/criteo/publisher/BidPrefetchRateLimiterTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/BidPrefetchRateLimiterTest.kt
@@ -1,0 +1,100 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher
+
+import android.content.SharedPreferences
+import com.criteo.publisher.BidPrefetchRateLimiter.Companion.STORAGE_KEY
+import com.criteo.publisher.BidPrefetchRateLimiter.Companion.UNSET_PREFETCH_TIME
+import com.criteo.publisher.model.Config
+import com.criteo.publisher.util.SafeSharedPreferences
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Before
+import org.junit.Test
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BidPrefetchRateLimiterTest {
+
+  @Mock
+  private lateinit var config: Config
+
+  @Mock
+  private lateinit var clock: Clock
+
+  @Mock
+  private lateinit var safeSharedPreferences: SafeSharedPreferences
+
+  @Mock
+  private lateinit var sharedPreferences: SharedPreferences
+
+  @InjectMocks
+  private lateinit var bidPrefetchRateLimiter: BidPrefetchRateLimiter
+
+  @Mock
+  private lateinit var editor: SharedPreferences.Editor
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.initMocks(this)
+  }
+
+  @Test
+  fun canPrefetch_givenFirstCallToBidPrefetch_ThenReturnTrue() {
+    whenever(safeSharedPreferences.getLong(STORAGE_KEY, UNSET_PREFETCH_TIME)).thenReturn(UNSET_PREFETCH_TIME)
+
+    assertTrue {
+      bidPrefetchRateLimiter.canPrefetch()
+    }
+  }
+
+  @Test
+  fun canPrefetch_givenImmediateSecondCallToBidPrefetch_ThenReturnFalse() {
+    whenever(safeSharedPreferences.getLong(STORAGE_KEY, UNSET_PREFETCH_TIME)).thenReturn(1L)
+    whenever(clock.currentTimeInMillis).thenReturn(2L)
+    whenever(config.minTimeBetweenPrefetchesMillis).thenReturn(2L)
+
+    assertFalse {
+      bidPrefetchRateLimiter.canPrefetch()
+    }
+  }
+
+  @Test
+  fun canPrefetch_givenNotImmediateSecondCallToBidPrefetch_ThenReturnFalse() {
+    whenever(safeSharedPreferences.getLong(STORAGE_KEY, UNSET_PREFETCH_TIME)).thenReturn(1L)
+    whenever(clock.currentTimeInMillis).thenReturn(3L)
+    whenever(config.minTimeBetweenPrefetchesMillis).thenReturn(2L)
+
+    assertTrue {
+      bidPrefetchRateLimiter.canPrefetch()
+    }
+  }
+
+  @Test
+  fun setPrefetchTime() {
+    whenever(sharedPreferences.edit()).thenReturn(editor)
+    whenever(clock.currentTimeInMillis).thenReturn(1L)
+
+    bidPrefetchRateLimiter.setPrefetchTime()
+
+    verify(editor).putLong(STORAGE_KEY, 1L)
+    verify(editor).apply()
+  }
+}

--- a/publisher-sdk/src/test/java/com/criteo/publisher/model/ConfigTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/model/ConfigTest.java
@@ -210,7 +210,8 @@ public class ConfigTest {
         null,
         "dataMacro",
         "dataMode",
-        false
+        false,
+        100L
     );
 
     doAnswer(answerVoid((RemoteConfigResponse ignored, OutputStream outputStream) -> {

--- a/test-utils/src/main/java/com/criteo/publisher/mock/MockedDependenciesRule.java
+++ b/test-utils/src/main/java/com/criteo/publisher/mock/MockedDependenciesRule.java
@@ -27,6 +27,7 @@ import android.os.Build.VERSION_CODES;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import com.criteo.publisher.BidPrefetchRateLimiter;
 import com.criteo.publisher.CriteoUtil;
 import com.criteo.publisher.DependencyProvider;
 import com.criteo.publisher.MockableDependencyProvider;


### PR DESCRIPTION
Problem:
For some publishers, the rate of bid requests is relatively higher on
Android than on other platforms. Our assumption is that those publishers
use services that cause Criteo to be initialized more than usual: for
instance on APIs lower than 26, it is possible to restart a service
automatically after the process has been killed.

Solution:
Two solutions were considered:
1. Initialize Criteo only if `Criteo#init` is called from a foreground
process. This would prevent `Criteo` to be initialized from a service, but
it has the adverse side effect of having `Criteo` instance stuck on
`DummyCriteo` instance (since `Criteo#getInstance()` does not attempt
any initialization).

2. Introduce rate limiting on bid requests. The bid request rate is
relatively high (compared to other platforms for the same publisher),
but completely normal/average from an absolute perspective (15-20
reqs/hour). For this reason, a simple strategy has been put in place:
only rate limit calls to prefetch by forbidding two consecutive calls to
prefetch.

The threshold representing the "consecutive" aspect can be configured
remotely but is set to 30 secs by default.

JIRA: EE-648