### PR TITLE
Fix tests and coverages on merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,18 +71,22 @@ jobs:
       - name: Set up Android SDK
         uses: malinskiy/action-android/install-sdk@release/0.0.7
 
-      # Run all tests on merge
+      # On merge, run non-flaky-tests without retry then flaky tests with retry policy
       - name: Run all Android tests
         uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
         if: github.event_name != 'pull_request'
         with:
           api: 29
           tag: google_apis
-          cmd: ./gradlew :publisher-sdk:gordon :publisher-sdk:createDebugAndroidTestCoverageReport
+          cmd: >
+            ./gradlew connectedCheck
+            -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.FlakyTest
+            &&
+            ./gradlew gordon --tests=androidx.test.filters.FlakyTest
           # Use a medium size skin rather than default size. Some tests need to have a decent size.
           cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -skin 360x640
 
-      # Run deterministic tests on PR
+      # Run only non-flaky tests on PR
       - name: Run Android tests w/o @FlakyTest
         uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
         if: github.event_name == 'pull_request'
@@ -107,7 +111,7 @@ jobs:
         if: failure()
         with:
           access-token: ${{ secrets.GITHUB_TOKEN }}
-          path: "**/build/test-results/**/*.xml"
+          path: "**/build/(test-results|reports)/**/*.xml"
 
       - name: Upload all (JUnit+Jacoco) report
         uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
           api: 29
           tag: google_apis
           cmd: >
-            ./gradlew :publisher-sdk:connectedCheck
+            ./gradlew connectedCheck
             -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.FlakyTest
           # Use a medium size skin rather than default size. Some tests need to have a decent size.
           cmdOptions: -no-snapshot-save -noaudio -no-boot-anim -skin 360x640

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Chris Beams - [How to Write a Git Commit Message](https://chris.beams.io/posts/g
 * Use Java 8 or below to run Gradle commands
 * Building project: `./gradlew build`
 * Running Java tests: `./gradlew check`
-* Running Android tests: `./gradlew :publisher-sdk:connectedCheck`
+* Running Android tests: `./gradlew connectedCheck`
 
 ### List of modules
 

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -48,6 +48,8 @@ dependencies {
   testImplementation(Deps.Mockito.Kotlin)
   testImplementation(Deps.AssertJ.AssertJ)
 
+  androidTestImplementation(Deps.AndroidX.Test.Runner)
+
   detektPlugins(Deps.Detekt.DetektFormatting)
 }
 


### PR DESCRIPTION
On merge, all tests are run, but only flaky ones are retried.

Only tests declared as flaky are run with a retry policy. Other tests
are always run normally.
This prevents any true negative to pass the tests.
Also, the Gordon runner does not support Jacoco coverage. So only flaky
tests are not counted in the coverage report. Which is a good thing,
because we cannot affirm that something is really covered if the tests
are flaky.
Moreover, runners with retry policies, such as Gordon, are slow compared
to the default test runner. This would speed up the CI on merge.