### PR TITLE
Fix path of JUnit reports given to Sonar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,9 +57,10 @@ sonarqube {
         )
     )
 
-    val junitReports = allSubProjectsReports("**/TEST-*.xml") + // Normal tests
+    val junitReportFiles = allSubProjectsReports("**/TEST-*.xml") + // Normal tests
         allSubProjectsReports("test-results/gordon/*.xml") // Retried tests (Gordon runner)
-    property("sonar.junit.reportPaths", junitReports)
+    val junitReportDirs = junitReportFiles.mapNotNull { it.parentFile }.toSet()
+    property("sonar.junit.reportPaths", junitReportDirs)
 
     val lintReports = allSubProjectsReports("reports/lint-results.xml")
     property("sonar.androidLint.reportPaths", lintReports)


### PR DESCRIPTION
For those reports, Sonar is expecting paths to directories containing
files reports rather than the path to the files themselves.