### PR TITLE
Add synchronization on flaky test

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
@@ -20,6 +20,7 @@ import static com.criteo.publisher.CriteoUtil.givenInitializedCriteo;
 import static com.criteo.publisher.StubConstants.STUB_CREATIVE_IMAGE;
 import static com.criteo.publisher.StubConstants.STUB_DISPLAY_URL;
 import static com.criteo.publisher.concurrent.ThreadingUtil.runOnMainThreadAndWait;
+import static com.criteo.publisher.view.WebViewClicker.waitUntilWebViewIsLoaded;
 import static com.criteo.publisher.view.WebViewLookup.getRootView;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,6 +41,8 @@ import android.content.Intent;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
+import android.webkit.WebView;
+import androidx.annotation.NonNull;
 import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.CriteoBannerAdListener;
@@ -167,15 +170,24 @@ public class StandaloneFunctionalTest {
     CriteoSync sync = new CriteoSync(interstitial);
 
     View interstitialView1 = whenLoadingAndDisplayingAnInterstitial(interstitial, sync);
+    waitUntilInterstitialWebViewIsLoaded(interstitialView1);
     String html1 = webViewLookup.lookForHtmlContent(interstitialView1).get();
 
     sync.reset();
 
     View interstitialView2 = whenLoadingAndDisplayingAnInterstitial(interstitial, sync);
+    waitUntilInterstitialWebViewIsLoaded(interstitialView2);
     String html2 = webViewLookup.lookForHtmlContent(interstitialView2).get();
 
     assertThat(html1).contains(STUB_CREATIVE_IMAGE);
     assertThat(html2).contains(STUB_CREATIVE_IMAGE);
+  }
+
+  private void waitUntilInterstitialWebViewIsLoaded(@NonNull View interstitialView)
+      throws Exception {
+    for (WebView webView : webViewLookup.lookForWebViews(interstitialView)) {
+      waitUntilWebViewIsLoaded(webView);
+    }
   }
 
   @Test


### PR DESCRIPTION
The "whenLoadingAnInterstitial GivenBidAvailableTwice
DisplayUrlIsProperlyLoadedInInterstitialActivityTwice" in Standalone
tests is very very flaky and makes the build fail even after 5 retries.

The assertion shows that the webview does not seems to contains any HTML
yet. Although, the listeners are correctly notified and the interstitial
is marked as being loaded. This means that the creative is downloaded,
but not yet loaded in the webview.

There were already few cases before where a webview takes time to be
fully loaded. So we can hope that waiting for the webview content will
help to make this test pass.