### PR TITLE
Run CI on version branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - v*.*.* # Version branches such as v4.2.1
   pull_request:
 
 jobs:
@@ -168,7 +169,7 @@ jobs:
 
   deploy-development-artifacts:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' # Only deploy on merge
 
     needs:
       - java-tests


### PR DESCRIPTION
When developing on a branch, this will provide test and quality reports
like on main branch.
Moreover, Sonar needs the base branch to be analysed to produce correct
analysis. For instance, current PR on the v4.0.0 are getting bad Sonar
reports because v4.0.0 is still unknown to it.