### PR TITLE
Accept nullable value for GAID in test

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/BearcatPrivacyFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/BearcatPrivacyFunctionalTest.java
@@ -223,8 +223,9 @@ public class BearcatPrivacyFunctionalTest {
 
     if (callBearcat) {
       verify(pubSdkApi)
-          .postAppEvent(any(Integer.class), any(String.class), any(String.class), any(String.class),
-              any(Integer.class), any(), any());
+          .postAppEvent(any(Integer.class), any(String.class), any(), any(String.class),
+              any(Integer.class), any(), any()
+          );
     } else {
       verify(pubSdkApi, never())
           .postAppEvent(any(Integer.class), any(String.class), any(String.class), any(String.class),


### PR DESCRIPTION
This test is a little bit flaky and the assertion shows that the GAID is
null. Log has been setup on AdvertisingInfo class to find the cause. It
appears that the Google API may throw IOException sometimes:

```
[ 08-21 16:59:09.235  5120:12828 D/AdvertisingInfo ]
java.io.IOException: Interrupted exception
        at com.google.android.gms.ads.identifier.AdvertisingIdClient.zza(Unknown Source:25)
        at com.google.android.gms.ads.identifier.AdvertisingIdClient.zza(Unknown Source:25)
        at com.google.android.gms.ads.identifier.AdvertisingIdClient.getAdvertisingIdInfo(Unknown Source:47)
        at com.criteo.publisher.util.AdvertisingInfo$SafeAdvertisingIdClient.isLimitAdTrackingEnabled(AdvertisingInfo.java:80)
        at com.criteo.publisher.util.AdvertisingInfo.isLimitAdTrackingEnabled(AdvertisingInfo.java:60)
        at com.criteo.publisher.util.AdvertisingInfo.getAdvertisingId(AdvertisingInfo.java:46)
        at com.criteo.publisher.model.CdbRequestFactory.createRequest(CdbRequestFactory.java:75)
        at com.criteo.publisher.network.BidRequestSender$CdbCall.runSafely(BidRequestSender.java:190)
        at com.criteo.publisher.SafeRunnable.run(SafeRunnable.java:42)
        at com.criteo.publisher.network.BidRequestSender$1.run(BidRequestSender.java:145)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:462)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at com.criteo.publisher.concurrent.TrackingCommandsExecutor.lambda$execute$0(TrackingCommandsExecutor.java:41)
        at com.criteo.publisher.concurrent.-$$Lambda$TrackingCommandsExecutor$6onjJ6Z0XyMDDimTX2GTL0WvqUA.run(Unknown Source:4)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:919)
```

We cannot do a lot about this and we do not know how many times it
fails, and on which devices. Further work would need to be done if this
became an issue. In the meantime, the test is loosen to accept nullable
values.