### PR TITLE
Add synchronization on flaky test again

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
@@ -155,6 +155,7 @@ public class StandaloneFunctionalTest {
     CriteoInterstitial interstitial = createInterstitial(validInterstitialAdUnit);
     CriteoSync sync = new CriteoSync(interstitial);
     View interstitialView = whenLoadingAndDisplayingAnInterstitial(interstitial, sync);
+    waitUntilInterstitialWebViewIsLoaded(interstitialView);
     String html = webViewLookup.lookForHtmlContent(interstitialView).get();
 
     assertThat(html).contains(STUB_CREATIVE_IMAGE);


### PR DESCRIPTION
The "whenLoadingAnInterstitial GivenBidAvailable*" in Standalone
tests is very very flaky and makes the build fail even after 5 retries.

Like on #74 (23e29ea), the test waits for the webview to be ready before
reading the HTML.