### PR TITLE
Resynchronize CDB stub with preprod

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/network/PubSdkApiIntegrationTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/network/PubSdkApiIntegrationTest.java
@@ -178,6 +178,7 @@ public class PubSdkApiIntegrationTest {
     assertThat(response.getTimeToNextCall()).isZero();
     assertThat(response.getSlots()).hasSize(1).allSatisfy(slot -> {
       assertThat(slot.getImpressionId()).isNotNull();
+      assertThat(slot.getZoneId()).isNotNull();
       assertThat(slot.isNative()).isFalse();
       assertThat(slot.getPlacementId()).isEqualTo(BANNER_320_50.getAdUnitId());
       assertThat(slot.getCpm()).isNotEmpty();
@@ -203,6 +204,7 @@ public class PubSdkApiIntegrationTest {
     assertThat(response.getTimeToNextCall()).isZero();
     assertThat(response.getSlots()).hasSize(1).allSatisfy(slot -> {
       assertThat(slot.getImpressionId()).isNotNull();
+      assertThat(slot.getZoneId()).isNotNull();
       assertThat(slot.isNative()).isFalse();
       assertThat(slot.getPlacementId()).isEqualTo(INTERSTITIAL.getAdUnitId());
       assertThat(slot.getCpm()).isNotEmpty();
@@ -226,13 +228,14 @@ public class PubSdkApiIntegrationTest {
     assertThat(response.getTimeToNextCall()).isZero();
     assertThat(response.getSlots()).hasSize(1).allSatisfy(slot -> {
       assertThat(slot.getImpressionId()).isNotNull();
+      assertThat(slot.getZoneId()).isNotNull();
       assertThat(slot.isNative()).isTrue();
       assertThat(slot.getPlacementId()).isEqualTo(NATIVE.getAdUnitId());
       assertThat(slot.getCpm()).isNotEmpty();
       assertThat(slot.getWidth()).isEqualTo(2);
       assertThat(slot.getHeight()).isEqualTo(2);
       assertThat(slot.getCurrency()).isNotEmpty();
-      assertThat(slot.getTtlInSeconds()).isEqualTo(0);
+      assertThat(slot.getTtlInSeconds()).isEqualTo(3600);
       assertThat(slot.getDisplayUrl()).isNull();
       assertThat(slot.getNativeAssets()).isEqualTo(StubConstants.STUB_NATIVE_ASSETS);
       assertThat(slot.isValid()).isTrue();

--- a/test-utils/src/main/java/com/criteo/publisher/mock/CdbMock.kt
+++ b/test-utils/src/main/java/com/criteo/publisher/mock/CdbMock.kt
@@ -45,8 +45,10 @@ class CdbMock(private val jsonSerializer: JsonSerializer) {
     const val TCF2_CONSENT_NOT_GIVEN = "COwJDpQOwJDpQIAAAAENAPCgAAAAAAAAAAAAAxQAgAsABiAAAAAA"
     const val TCF1_CONSENT_NOT_GIVEN = "BOnz82JOnz82JABABBFRCPgAAAAFuABABAA"
 
-    // Use any ZoneId as CDB preprod returns an auto-incremented ID coming from DB
-    private const val DUMMY_ZONE_ID = 1337
+    private const val PREPROD_ZONE_ID = 0
+    private const val PREPROD_TTL = 3600
+    private const val PREPROD_CPM = "1.12"
+    private const val PREPROD_CURRENCY = "EUR"
 
     private const val CONTENT_TYPE = "content-type"
   }
@@ -158,12 +160,12 @@ class CdbMock(private val jsonSerializer: JsonSerializer) {
           "impId": "$impressionId",
           "placementId": "$placementId",
           "arbitrageId": "arbitrage_id",
-          "zoneId": $DUMMY_ZONE_ID,
-          "cpm": "1.12",
-          "currency": "EUR",
+          "zoneId": $PREPROD_ZONE_ID,
+          "cpm": "$PREPROD_CPM",
+          "currency": "$PREPROD_CURRENCY",
           "width": $width,
           "height": $height,
-          "ttl": 3600,
+          "ttl": $PREPROD_TTL,
           "displayUrl": "$url/delivery/ajs.php?width=$width&height=$height"
         }
       """.trimIndent()
@@ -174,12 +176,12 @@ class CdbMock(private val jsonSerializer: JsonSerializer) {
           "impId": "$impressionId",
           "placementId": "$placementId",
           "arbitrageId": "",
-          "zoneId": $DUMMY_ZONE_ID,
-          "cpm": "1.12",
-          "currency": "EUR",
+          "zoneId": $PREPROD_ZONE_ID,
+          "cpm": "$PREPROD_CPM",
+          "currency": "$PREPROD_CURRENCY",
           "width": $width,
           "height": $height,
-          "ttl": 0,
+          "ttl": $PREPROD_TTL,
           "native": $STUB_NATIVE_JSON
         }
       """.trimIndent()


### PR DESCRIPTION
The stub vs preprod tests are failing because of couple diffs:
- Zone ID is always 0 on the preprod
- TTL is always 3600

Constants are used to reduce work in case of update.