### PR TITLE
Fix functional tests after merging interstitial listeners

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/StandaloneFunctionalTest.java
@@ -465,7 +465,7 @@ public class StandaloneFunctionalTest {
     CriteoSync(CriteoInterstitial interstitial) {
       this.handler = new Handler(Looper.getMainLooper());
       this.init = () -> {
-        this.isLoaded = new CountDownLatch(2);
+        this.isLoaded = new CountDownLatch(1);
         this.isDisplayed = new CountDownLatch(1);
       };
 


### PR DESCRIPTION
The test was expecting two callbacks from the old interstitial
listeners: `onAdReceived` and `onAdReadyToDisplay`. With the merge of
the listeners, there is now only one callback fired when the
interstitial is ready to be displayed.

Note that this was not caught by CI, because during PR, only
deterministic tests are run, and flaky tests, such as this one, are only
run at merge, which is only activated recently on version branches.