### PR TITLE
Fetch the whole Git history when running Sonar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # Fetch the whole history to activate the auto-assignment of Sonar issues.
+          # Also, Sonar needs the base branch to be fetched in order to provide a good report.
+          fetch-depth: 0
 
       # Sonar drops support of Java 8 in favor of the new LTS: Java 11.
       # See https://sonarcloud.io/documentation/user-guide/move-analysis-java-11/


### PR DESCRIPTION
Currently we have two warnings on Sonar reports:
```
Could not find ref 'main' in refs/heads, refs/remotes/upstream or
refs/remotes/origin. You may see unexpected issues and changes. Please
make sure to fetch this ref before pull request analysis.
```

and

```
Shallow clone detected during the analysis. Some files will miss SCM
information. This will affect features like auto-assignment of issues.
Please configure your build to disable shallow clone.
```

The first one seems to be the origin of wrong coverage rate and issues
reported in PRs.
The second one indicates that we're missing the auto-assignment of
issues because only the last commit was fetched.

By fetching the whole Git history, the warnings are solved, improving
the reporting on PR and introducing a new feature for free.