### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Next version
 
-- Features
-  - MoPub Header-Bidding: Handle subclasses of `MoPubView` and `MoPubInterstitial`
-
-- Bug fixes
-  - Fix wrong interstitial orientation when user starts the application in landscape
-
 # Version 4.0.0
 
 - Breaking changes

--- a/buildSrc/src/main/java/SdkVersion.kt
+++ b/buildSrc/src/main/java/SdkVersion.kt
@@ -18,7 +18,7 @@ import org.gradle.api.Project
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-private const val sdkBaseVersion = "3.9.0"
+private const val sdkBaseVersion = "4.0.0"
 
 private val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd.HHmm"))
 


### PR DESCRIPTION
The bump is done now, ahead of time to avoid polluting 3.9.0 artifacts
with breaking changes from the v4.0.0.