### PR TITLE
Fix declaration of version 3.10.0 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 3.10.0
+# Version 3.10.0
 
 - Features
   - MoPub Header-Bidding: Handle subclasses of `MoPubView` and `MoPubInterstitial`


### PR DESCRIPTION
The changelog extractor is defined to search sections containing the
text `# Version $version`.