### PR TITLE
Trigger onAdReceived for server-side bidding

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoBannerEventController.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoBannerEventController.java
@@ -90,7 +90,7 @@ public class CriteoBannerEventController {
     }
   }
 
-  private void notifyFor(@NonNull CriteoListenerCode code) {
+  void notifyFor(@NonNull CriteoListenerCode code) {
     executor.executeAsync(new CriteoBannerListenerCallTask(adListener, view, code));
   }
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoBannerView.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoBannerView.java
@@ -93,6 +93,7 @@ public class CriteoBannerView extends WebView {
 
   @Keep
   public void loadAdWithDisplayData(@NonNull String displayData) {
+    getOrCreateController().notifyFor(CriteoListenerCode.VALID);
     getOrCreateController().displayAd(displayData);
   }
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitial.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitial.java
@@ -111,6 +111,7 @@ public class CriteoInterstitial {
 
   @Keep
   public void loadAdWithDisplayData(@NonNull String displayData) {
+    getOrCreateController().notifyFor(CriteoListenerCode.VALID);
     getOrCreateController().fetchCreativeAsync(displayData);
   }
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitialEventController.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitialEventController.java
@@ -109,7 +109,6 @@ public class CriteoInterstitialEventController {
     }
   }
 
-  @VisibleForTesting
   void notifyFor(@NonNull CriteoListenerCode code) {
     executor
         .executeAsync(new CriteoInterstitialListenerCallTask(criteoInterstitialAdListener, code));

--- a/publisher-sdk/src/test/java/com/criteo/publisher/CriteoBannerViewTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/CriteoBannerViewTest.java
@@ -228,6 +228,7 @@ public class CriteoBannerViewTest {
   @Test
   public void displayAd_GivenController_DelegateToIt() throws Exception {
     bannerView.loadAdWithDisplayData("fake_display_data");
+    verify(controller).notifyFor(CriteoListenerCode.VALID);
     verify(controller).displayAd("fake_display_data");
   }
 

--- a/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInterstitialTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInterstitialTest.java
@@ -157,6 +157,7 @@ public class CriteoInterstitialTest {
   public void displayAd_GivenController_DelegateToIt() throws Exception {
     CriteoInterstitialEventController controller = givenMockedController();
     interstitial.loadAdWithDisplayData("fake_display_data");
+    verify(controller).notifyFor(CriteoListenerCode.VALID);
     verify(controller).fetchCreativeAsync("fake_display_data");
   }
 


### PR DESCRIPTION
While semantically, the ad has already loaded before displaying it, we
still want to distinguish between success and failure cases (invalid
display data for example).