### PR TITLE
Use DummyCriteo if not initialized properly

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/Criteo.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/Criteo.java
@@ -116,9 +116,8 @@ public abstract class Criteo {
           } else {
             criteo = new DummyCriteo();
           }
-        } catch (IllegalArgumentException iae) {
-          throw iae;
-        } catch (Throwable tr) {
+        } catch(Throwable tr) {
+          criteo = new DummyCriteo();
           Log.e(TAG, "Internal error initializing Criteo instance.", tr);
           throw new CriteoInitException("Internal error initializing Criteo instance.", tr);
         }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
@@ -94,7 +94,7 @@ final class CriteoInternal extends Criteo {
       userPrivacyUtil.storeUsPrivacyOptout(usPrivacyOptout);
     }
 
-    // this nulll check ensures that instantiating Criteo object with null mopub consent value,
+    // this null check ensures that instantiating Criteo object with null mopub consent value,
     // doesn't erase the previously stored consent value
     if (mopubConsent != null) {
       userPrivacyUtil.storeMopubConsent(mopubConsent);

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitial.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitial.java
@@ -79,16 +79,23 @@ public class CriteoInterstitial {
   }
 
   public void setCriteoInterstitialAdListener(
-      @Nullable CriteoInterstitialAdListener criteoInterstitialAdListener) {
+      @Nullable CriteoInterstitialAdListener criteoInterstitialAdListener
+  ) {
     this.criteoInterstitialAdListener = criteoInterstitialAdListener;
   }
 
   public void setCriteoInterstitialAdDisplayListener(
-      @Nullable CriteoInterstitialAdDisplayListener criteoInterstitialAdDisplayListener) {
+      @Nullable CriteoInterstitialAdDisplayListener criteoInterstitialAdDisplayListener
+  ) {
     this.criteoInterstitialAdDisplayListener = criteoInterstitialAdDisplayListener;
   }
 
   public void loadAd() {
+    if (!DependencyProvider.getInstance().isApplicationSet()) {
+      Log.w(TAG, "Calling CriteoInterstitial#loadAd with a null application");
+      return;
+    }
+
     try {
       doLoadAd();
     } catch (Throwable tr) {
@@ -102,6 +109,11 @@ public class CriteoInterstitial {
   }
 
   public void loadAd(@Nullable BidToken bidToken) {
+    if (!DependencyProvider.getInstance().isApplicationSet()) {
+      Log.w(TAG, "Calling CriteoInterstitial#loadAd(bidToken) with a null application");
+      return;
+    }
+
     try {
       doLoadAd(bidToken);
     } catch (Throwable tr) {
@@ -111,6 +123,11 @@ public class CriteoInterstitial {
 
   @Keep
   public void loadAdWithDisplayData(@NonNull String displayData) {
+    if (!DependencyProvider.getInstance().isApplicationSet()) {
+      Log.w(TAG, "Calling CriteoInterstitial#loadAdWithDisplayData with a null application");
+      return;
+    }
+
     getOrCreateController().notifyFor(CriteoListenerCode.VALID);
     getOrCreateController().fetchCreativeAsync(displayData);
   }
@@ -133,6 +150,11 @@ public class CriteoInterstitial {
   }
 
   public void show() {
+    if (!DependencyProvider.getInstance().isApplicationSet()) {
+      Log.w(TAG, "Calling CriteoInterstitial#show with a null application");
+      return;
+    }
+
     try {
       doShow();
     } catch (Throwable tr) {

--- a/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
@@ -129,6 +129,15 @@ public class DependencyProvider {
     this.criteoPublisherId = criteoPublisherId;
     checkCriteoPublisherIdIsSet();
   }
+  
+  boolean isApplicationSet() {
+    try {
+      DependencyProvider.getInstance().checkApplicationIsSet();
+    } catch (Exception e) {
+      return false;
+    }
+    return true;
+  }
 
   private void checkApplicationIsSet() {
     if (application == null) {
@@ -285,7 +294,8 @@ public class DependencyProvider {
       public DeviceInfo create() {
         return new DeviceInfo(
             provideContext(),
-            provideRunOnUiThreadExecutor());
+            provideRunOnUiThreadExecutor()
+        );
       }
     });
   }
@@ -298,7 +308,8 @@ public class DependencyProvider {
       public AdUnitMapper create() {
         return new AdUnitMapper(
             DependencyProvider.this.provideAndroidUtil(),
-            DependencyProvider.this.provideDeviceUtil());
+            DependencyProvider.this.provideDeviceUtil()
+        );
       }
     });
   }
@@ -771,6 +782,7 @@ public class DependencyProvider {
   }
 
   public interface Factory<T> {
+
     @NonNull
     T create();
   }

--- a/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInterstitialTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInterstitialTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
+import android.app.Application;
 import android.content.Context;
 import com.criteo.publisher.integration.Integration;
 import com.criteo.publisher.integration.IntegrationRegistry;
@@ -159,6 +160,61 @@ public class CriteoInterstitialTest {
     interstitial.loadAdWithDisplayData("fake_display_data");
     verify(controller).notifyFor(CriteoListenerCode.VALID);
     verify(controller).fetchCreativeAsync("fake_display_data");
+  }
+
+  @Test
+  public void loadAd_GivenNullApplication_ReturnImmediately() throws Exception {
+    CriteoInterstitialEventController controller = givenMockedController();
+    Application application = givenNullApplication();
+
+    interstitial.loadAd();
+
+    verifyNoMoreInteractions(controller);
+    DependencyProvider.getInstance().setApplication(application);
+  }
+
+  @Test
+  public void loadAdWithBidToken_GivenNullApplication_ReturnImmediately() throws Exception {
+    CriteoInterstitialEventController controller = givenMockedController();
+    Application application = givenNullApplication();
+    BidToken token = new BidToken(UUID.randomUUID(), adUnit);
+
+    interstitial.loadAd(token);
+
+    verifyNoMoreInteractions(controller);
+    DependencyProvider.getInstance().setApplication(application);
+  }
+
+  @Test
+  public void loadAdWithDisplayData_GivenNullApplication_ReturnImmediately() throws Exception {
+    CriteoInterstitialEventController controller = givenMockedController();
+    Application application = givenNullApplication();
+
+    interstitial.loadAdWithDisplayData("");
+
+    verifyNoMoreInteractions(controller);
+    DependencyProvider.getInstance().setApplication(application);
+  }
+
+
+  @Test
+  public void show_GivenNullApplication_ReturnImmediately() throws Exception {
+    CriteoInterstitialEventController controller = givenMockedController();
+    Application application = givenNullApplication();
+
+    interstitial.show();
+
+    verifyNoMoreInteractions(controller);
+    DependencyProvider.getInstance().setApplication(application);
+  }
+
+  private Application givenNullApplication() {
+    Application application = DependencyProvider.getInstance().provideApplication();
+    try {
+      DependencyProvider.getInstance().setApplication(null);
+    } catch (Exception e) {
+    }
+    return application;
   }
 
   private CriteoInterstitialEventController givenMockedController() {

--- a/publisher-sdk/src/test/java/com/criteo/publisher/CriteoTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/CriteoTest.java
@@ -16,12 +16,20 @@
 
 package com.criteo.publisher;
 
-public class CriteoNotInitializedException extends IllegalStateException {
+import static junit.framework.TestCase.assertEquals;
 
-  public CriteoNotInitializedException(String message) {
-    super(message + "\n"
-        + "Did you properly initialize the Criteo SDK ?\n"
-        + "Please follow this step: https://publisherdocs.criteotilt.com/app/android/standalone/#sdk-initialization\n");
+import org.junit.Test;
+
+public class CriteoTest {
+
+  @Test
+  public void criteoInit_GivenNullApplication_DoesNotCrash() {
+    try {
+      new Criteo.Builder(null, "").init();
+    } catch (CriteoInitException e) {
+    }
+
+    assertEquals(DummyCriteo.class, Criteo.getInstance().getClass());
   }
 
 }


### PR DESCRIPTION
Problem:
When an error happens during the initialization path, Criteo instance
will be `null` and any future call to Criteo.getInstance() will throw a
RuntimeException.

Solution:
DummyCriteo is assigned to Criteo singleton object, when any runtime
exception is thrown during initialization. While the integration will
not work, it will prevent the host application from crashing. Logging
will allow us to investigate and correct the root cause with the
publisher.

-----
Guard against null application in CriteoInterstitial

Problem:
An `application` object is required for the SDK to operate properly.
However, nothing prevents CriteoInterstitialActivity from being open even if
`application` is null.

Solution:
CriteoInterstitial APIs must check wehther `application` is null or
return immediately. This is a workaround to prevent apps from crashing
in production but actions need to be taken in the future to:
1. Understand how `application` can be null for publishers.
2. Check whether we can reduce the scope of `application` within the SDk
and use an Activity context when appropriate (in this case, the Activity
context that is passed to CriteoInterstitial could be used).
3. Understand the implications of making the application object
nullable.