### PR TITLE
Draft: Use Activity context for Redirection

### DIFF
--- a/app/src/main/java/com/criteo/testapp/InHouseActivity.java
+++ b/app/src/main/java/com/criteo/testapp/InHouseActivity.java
@@ -118,7 +118,7 @@ public class InHouseActivity extends AppCompatActivity {
 
   private void loadNative() {
     BidResponse bidResponse = Criteo.getInstance().getBidResponse(NATIVE);
-    nativeLoader.loadAd(bidResponse.getBidToken());
+    nativeLoader.loadAd(this, bidResponse.getBidToken());
   }
 
   private void loadInterstitialAd(InterstitialAdUnit adUnit, Button btnShow) {

--- a/app/src/main/java/com/criteo/testapp/StandaloneActivity.java
+++ b/app/src/main/java/com/criteo/testapp/StandaloneActivity.java
@@ -111,7 +111,7 @@ public class StandaloneActivity extends AppCompatActivity {
   }
 
   private void loadNative() {
-    nativeLoader.loadAd();
+    nativeLoader.loadAd(this);
   }
 
   private void loadInterstitial(InterstitialAdUnit adUnit, Button btnShow) {

--- a/app/src/main/java/com/criteo/testapp/StandaloneRecyclerViewActivity.kt
+++ b/app/src/main/java/com/criteo/testapp/StandaloneRecyclerViewActivity.kt
@@ -71,7 +71,7 @@ class StandaloneRecyclerViewActivity : AppCompatActivity() {
     }
 
     findViewById<View>(R.id.buttonStandaloneNative).setOnClickListener {
-      nativeLoader.loadAd()
+      nativeLoader.loadAd(this)
     }
   }
 

--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/ProfileIdFunctionalTest.kt
@@ -213,7 +213,7 @@ class ProfileIdFunctionalTest {
     givenPreviousInHouseIntegration()
 
     givenInitializedCriteo()
-    CriteoNativeLoader(NATIVE, mock(), mock()).loadAd()
+    CriteoNativeLoader(NATIVE, mock(), mock()).loadAd(context)
     mockedDependenciesRule.waitForIdleState()
 
     verifyCdbIsCalledWith(Integration.STANDALONE)

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitialActivity.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitialActivity.java
@@ -117,6 +117,7 @@ public class CriteoInterstitialActivity extends Activity {
     );
 
     AdWebViewClient adWebViewClient = new AdWebViewClient(
+        this,
         weakRedirectionListener,
         callingActivityName
     );

--- a/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
@@ -429,26 +429,37 @@ public class DependencyProvider {
   }
 
   @NonNull
-  public NativeAdMapper provideNativeAdMapper() {
+  public NativeAdMapper provideNativeAdMapper(@NonNull Context context) {
     return getOrCreate(NativeAdMapper.class, new Factory<NativeAdMapper>() {
       @NonNull
       @Override
       public NativeAdMapper create() {
         return new NativeAdMapper(
             provideVisibilityTracker(),
-            new ImpressionHelper(
-                providePubSdkApi(),
-                provideThreadPoolExecutor(),
-                provideRunOnUiThreadExecutor()
-            ),
+            provideImpressionHelper(),
             provideClickDetection(),
             new ClickHelper(
-                provideRedirection(),
+                provideRedirection(context),
                 provideTopActivityFinder(),
                 provideRunOnUiThreadExecutor()
             ),
             provideAdChoiceOverlay(),
             provideRendererHelper()
+        );
+      }
+    });
+  }
+
+  @NonNull
+  public ImpressionHelper provideImpressionHelper() {
+    return getOrCreate(ImpressionHelper.class, new Factory<ImpressionHelper>() {
+      @NonNull
+      @Override
+      public ImpressionHelper create() {
+        return new ImpressionHelper(
+            providePubSdkApi(),
+            provideThreadPoolExecutor(),
+            provideRunOnUiThreadExecutor()
         );
       }
     });
@@ -477,12 +488,12 @@ public class DependencyProvider {
   }
 
   @NonNull
-  public Redirection provideRedirection() {
+  public Redirection provideRedirection(@NonNull Context context) {
     return getOrCreate(Redirection.class, new Factory<Redirection>() {
       @NonNull
       @Override
       public Redirection create() {
-        return new Redirection(provideContext());
+        return new Redirection(context);
       }
     });
   }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/advancednative/CriteoNativeLoader.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/advancednative/CriteoNativeLoader.java
@@ -112,43 +112,43 @@ public class CriteoNativeLoader {
    * be notified by the {@link CriteoNativeAdListener#onAdFailedToReceive(CriteoErrorCode)}
    * callback.
    */
-  public void loadAd() {
+  public void loadAd(@NonNull Context context) {
     try {
-      doLoad();
+      doLoad(context);
     } catch (Throwable t) {
       PreconditionsUtil.throwOrLog(t);
     }
   }
 
-  private void doLoad() {
+  private void doLoad(@NonNull Context context) {
     getIntegrationRegistry().declare(Integration.STANDALONE);
 
     BidManager bidManager = getBidManager();
     CdbResponseSlot bid = bidManager.getBidForAdUnitAndPrefetch(adUnit);
     NativeAssets assets = bid == null ? null : bid.getNativeAssets();
-    handleNativeAssets(assets);
+    handleNativeAssets(context, assets);
   }
 
-  public void loadAd(@Nullable BidToken bidToken) {
+  public void loadAd(@NonNull Context context, @Nullable BidToken bidToken) {
     try {
-      doLoad(bidToken);
+      doLoad(context, bidToken);
     } catch (Throwable t) {
       PreconditionsUtil.throwOrLog(t);
     }
   }
 
-  private void doLoad(@Nullable BidToken bidToken) {
+  private void doLoad(@NonNull Context context, @Nullable BidToken bidToken) {
     InHouse inHouse = getInHouse();
     NativeTokenValue tokenValue = inHouse.getNativeTokenValue(bidToken);
     NativeAssets assets = tokenValue == null ? null : tokenValue.getNativeAssets();
-    handleNativeAssets(assets);
+    handleNativeAssets(context, assets);
   }
 
-  private void handleNativeAssets(@Nullable NativeAssets assets) {
+  private void handleNativeAssets(@NonNull Context context, @Nullable NativeAssets assets) {
     if (assets == null) {
       notifyForFailureAsync();
     } else {
-      NativeAdMapper nativeAdMapper = getNativeAdMapper();
+      NativeAdMapper nativeAdMapper = getNativeAdMapper(context);
       CriteoNativeAd nativeAd = nativeAdMapper.map(
           assets,
           new WeakReference<>(listener),
@@ -185,8 +185,8 @@ public class CriteoNativeLoader {
   }
 
   @NonNull
-  private NativeAdMapper getNativeAdMapper() {
-    return DependencyProvider.getInstance().provideNativeAdMapper();
+  private NativeAdMapper getNativeAdMapper(@NonNull Context context) {
+    return DependencyProvider.getInstance().provideNativeAdMapper(context);
   }
 
   @NonNull

--- a/publisher-sdk/src/main/java/com/criteo/publisher/adview/AdWebViewClient.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/adview/AdWebViewClient.java
@@ -17,6 +17,7 @@
 package com.criteo.publisher.adview;
 
 import android.content.ComponentName;
+import android.content.Context;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.annotation.NonNull;
@@ -35,12 +36,13 @@ public class AdWebViewClient extends WebViewClient {
   private final Redirection redirection;
 
   public AdWebViewClient(
+      @NonNull Context context,
       @NonNull RedirectionListener listener,
       @Nullable ComponentName hostActivityName
   ) {
     this.listener = listener;
     this.hostActivityName = hostActivityName;
-    this.redirection = DependencyProvider.getInstance().provideRedirection();
+    this.redirection = DependencyProvider.getInstance().provideRedirection(context);
   }
 
   @Override

--- a/publisher-sdk/src/test/java/com/criteo/publisher/advancednative/CriteoNativeLoaderTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/advancednative/CriteoNativeLoaderTest.kt
@@ -16,6 +16,7 @@
 
 package com.criteo.publisher.advancednative
 
+import android.content.Context
 import com.criteo.publisher.BidManager
 import com.criteo.publisher.CriteoErrorCode
 import com.criteo.publisher.InHouse
@@ -63,6 +64,9 @@ class CriteoNativeLoaderTest {
   @Inject
   private lateinit var imageLoaderHolder: ImageLoaderHolder
 
+  @Inject
+  private lateinit var context: Context
+
   @SpyBean
   private lateinit var buildConfigWrapper: BuildConfigWrapper
 
@@ -106,7 +110,7 @@ class CriteoNativeLoaderTest {
   fun loadAdInHouse_GivenNoBid_NotifyListenerOnUiThreadForFailure() {
     expectListenerToBeCalledOnUiThread()
 
-    nativeLoader.loadAd(null)
+    nativeLoader.loadAd(context, null)
 
     verify(listener).onAdFailedToReceive(CriteoErrorCode.ERROR_CODE_NO_FILL)
     verifyNoMoreInteractions(listener)
@@ -120,7 +124,7 @@ class CriteoNativeLoaderTest {
     givenNotANativeBidAvailable()
 
     val bidResponse = inHouse.getBidResponse(adUnit)
-    nativeLoader.loadAd(bidResponse.bidToken)
+    nativeLoader.loadAd(context, bidResponse.bidToken)
 
     verify(listener).onAdFailedToReceive(CriteoErrorCode.ERROR_CODE_NO_FILL)
     verifyNoMoreInteractions(listener)
@@ -134,7 +138,7 @@ class CriteoNativeLoaderTest {
     val nativeAd = givenNativeBidAvailable()
 
     val bidResponse = inHouse.getBidResponse(adUnit)
-    nativeLoader.loadAd(bidResponse.bidToken)
+    nativeLoader.loadAd(context, bidResponse.bidToken)
 
     verify(listener).onAdReceived(nativeAd)
     verifyNoMoreInteractions(listener)
@@ -147,7 +151,7 @@ class CriteoNativeLoaderTest {
     expectListenerToBeCalledOnUiThread()
     givenNoBidAvailable()
 
-    nativeLoader.loadAd()
+    nativeLoader.loadAd(context)
 
     verify(listener).onAdFailedToReceive(CriteoErrorCode.ERROR_CODE_NO_FILL)
     verifyNoMoreInteractions(listener)
@@ -160,7 +164,7 @@ class CriteoNativeLoaderTest {
     expectListenerToBeCalledOnUiThread()
     val nativeAd = givenNativeBidAvailable()
 
-    nativeLoader.loadAd()
+    nativeLoader.loadAd(context)
 
     verify(listener).onAdReceived(nativeAd)
     verifyNoMoreInteractions(listener)
@@ -173,7 +177,7 @@ class CriteoNativeLoaderTest {
     expectListenerToBeCalledOnUiThread()
     givenNotANativeBidAvailable()
 
-    nativeLoader.loadAd()
+    nativeLoader.loadAd(context)
 
     verify(listener).onAdFailedToReceive(CriteoErrorCode.ERROR_CODE_NO_FILL)
     verifyNoMoreInteractions(listener)
@@ -191,7 +195,7 @@ class CriteoNativeLoaderTest {
 
     // then
     assertThatCode {
-      nativeLoader.loadAd()
+      nativeLoader.loadAd(context)
     }.doesNotThrowAnyException()
   }
 

--- a/publisher-sdk/src/test/java/com/criteo/publisher/advancednative/NativeAdMapperTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/advancednative/NativeAdMapperTest.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import com.criteo.publisher.DependencyProvider
 import com.criteo.publisher.activity.TopActivityFinder
 import com.criteo.publisher.adview.Redirection
 import com.criteo.publisher.concurrent.RunOnUiThreadExecutor
@@ -30,14 +31,27 @@ import com.criteo.publisher.mock.SpyBean
 import com.criteo.publisher.model.nativeads.NativeAssets
 import com.criteo.publisher.model.nativeads.NativeProduct
 import com.criteo.publisher.network.PubSdkApi
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.stub
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Answers
 import java.lang.ref.WeakReference
 import java.net.URI
-import javax.inject.Inject
 
 class NativeAdMapperTest {
 
@@ -69,8 +83,19 @@ class NativeAdMapperTest {
   @MockBean
   private lateinit var api: PubSdkApi
 
-  @Inject
+  @MockBean
+  private lateinit var impressionHelper: ImpressionHelper
+
   private lateinit var mapper: NativeAdMapper
+
+  @Before
+  fun setUp() {
+    mapper = NativeAdMapper(visibilityTracker, impressionHelper, clickDetection, ClickHelper(
+        redirection,
+        topActivityFinder,
+        runOnUiThreadExecutor
+    ), adChoiceOverlay, rendererHelper)
+  }
 
   @Test
   fun map_GivenAssets_ReturnsNativeAdWithSameDataAndPreloadImages() {


### PR DESCRIPTION
It appears that there are cases where the `application` is null. To
mitigate against these cases, we should rely as little as possible on
the app context and use Activity context when available.