### PR TITLE
Rename BidListener into CdbResponseSlotListener

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/CdbResponseSlotListener.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CdbResponseSlotListener.kt
@@ -19,10 +19,10 @@ package com.criteo.publisher
 import com.criteo.publisher.model.CdbResponseSlot
 
 /**
- * Callback through which bid responses will be served asynchronously.
+ * Callback through which [CdbResponseSlot] responses will be served asynchronously.
  * Each of the callback methods will only be called once.
  */
-interface BidListener {
+interface CdbResponseSlotListener {
   fun onBidResponse(cdbResponseSlot: CdbResponseSlot)
 
   fun onNoBid()

--- a/publisher-sdk/src/main/java/com/criteo/publisher/Criteo.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/Criteo.java
@@ -142,7 +142,7 @@ public abstract class Criteo {
   public abstract void setBidsForAdUnit(Object object, AdUnit adUnit);
 
   @Nullable
-  abstract void getBidForAdUnit(@Nullable AdUnit adUnit, @NonNull BidListener bidListener);
+  abstract void getBidForAdUnit(@Nullable AdUnit adUnit, @NonNull CdbResponseSlotListener cdbResponseSlotListener);
 
   public abstract BidResponse getBidResponse(AdUnit adUnit);
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoBannerEventController.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoBannerEventController.java
@@ -69,7 +69,7 @@ public class CriteoBannerEventController {
   }
 
   public void fetchAdAsync(@Nullable AdUnit adUnit) {
-   criteo.getBidForAdUnit(adUnit, new BidListener() {
+   criteo.getBidForAdUnit(adUnit, new CdbResponseSlotListener() {
       @Override
       public void onBidResponse(@NonNull CdbResponseSlot cdbResponseSlot) {
         notifyFor(VALID);

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
@@ -138,8 +138,8 @@ final class CriteoInternal extends Criteo {
    * [Standalone only]
    */
   @Override
-  void getBidForAdUnit(AdUnit adUnit, @NonNull BidListener bidListener) {
-    bidManager.getBidForAdUnit(adUnit, bidListener);
+  void getBidForAdUnit(AdUnit adUnit, @NonNull CdbResponseSlotListener cdbResponseSlotListener) {
+    bidManager.getBidForAdUnit(adUnit, cdbResponseSlotListener);
   }
 
   @Override

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitialEventController.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInterstitialEventController.java
@@ -76,7 +76,7 @@ public class CriteoInterstitialEventController {
     }
 
     webViewData.downloadLoading();
-    criteo.getBidForAdUnit(adUnit, new BidListener() {
+    criteo.getBidForAdUnit(adUnit, new CdbResponseSlotListener() {
       @Override
       public void onBidResponse(@NonNull CdbResponseSlot cdbResponseSlot) {
         fetchCreativeAsync(cdbResponseSlot.getDisplayUrl());

--- a/publisher-sdk/src/main/java/com/criteo/publisher/DummyCriteo.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/DummyCriteo.java
@@ -39,8 +39,8 @@ public class DummyCriteo extends Criteo {
 
   @Nullable
   @Override
-  void getBidForAdUnit(@Nullable AdUnit adUnit, @NonNull BidListener bidListener) {
-    bidListener.onNoBid();
+  void getBidForAdUnit(@Nullable AdUnit adUnit, @NonNull CdbResponseSlotListener cdbResponseSlotListener) {
+    cdbResponseSlotListener.onNoBid();
   }
 
   @Override

--- a/publisher-sdk/src/main/java/com/criteo/publisher/advancednative/CriteoNativeLoader.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/advancednative/CriteoNativeLoader.java
@@ -22,7 +22,7 @@ import android.view.ViewGroup;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import com.criteo.publisher.BidListener;
+import com.criteo.publisher.CdbResponseSlotListener;
 import com.criteo.publisher.BidManager;
 import com.criteo.publisher.BidToken;
 import com.criteo.publisher.CriteoErrorCode;
@@ -124,7 +124,7 @@ public class CriteoNativeLoader {
   private void doLoad() {
     getIntegrationRegistry().declare(Integration.STANDALONE);
 
-    getBidManager().getBidForAdUnit(adUnit, new BidListener() {
+    getBidManager().getBidForAdUnit(adUnit, new CdbResponseSlotListener() {
       @Override
       public void onBidResponse(@NonNull CdbResponseSlot cdbResponseSlot) {
         handleNativeAssets(cdbResponseSlot.getNativeAssets());

--- a/publisher-sdk/src/test/java/com/criteo/publisher/BidManagerTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/BidManagerTest.kt
@@ -48,10 +48,10 @@ class BidManagerTest {
 
     val adUnit = mock<AdUnit>()
     val expected = mock<CdbResponseSlot>()
-    val bidListener = mock<BidListener>()
+    val bidListener = mock<CdbResponseSlotListener>()
 
     doAnswer {
-      it.getArgument<BidListener>(1).onBidResponse(expected)
+      it.getArgument<CdbResponseSlotListener>(1).onBidResponse(expected)
     }.whenever(bidManager).getLiveBidForAdUnit(adUnit, bidListener)
 
     bidManager.getBidForAdUnit(adUnit, bidListener)
@@ -65,10 +65,10 @@ class BidManagerTest {
     whenever(config.isLiveBiddingEnabled).thenReturn(true)
 
     val adUnit = mock<AdUnit>()
-    val bidListener = mock<BidListener>()
+    val bidListener = mock<CdbResponseSlotListener>()
 
     doAnswer {
-      it.getArgument<BidListener>(1).onNoBid()
+      it.getArgument<CdbResponseSlotListener>(1).onNoBid()
     }.whenever(bidManager).getLiveBidForAdUnit(adUnit, bidListener)
 
     bidManager.getBidForAdUnit(adUnit, bidListener)
@@ -83,7 +83,7 @@ class BidManagerTest {
 
     val adUnit = mock<AdUnit>()
     val expected = mock<CdbResponseSlot>()
-    val bidListener = mock<BidListener>()
+    val bidListener = mock<CdbResponseSlotListener>()
 
     doReturn(expected).whenever(bidManager).getBidForAdUnitAndPrefetch(adUnit)
 
@@ -98,7 +98,7 @@ class BidManagerTest {
     whenever(config.isLiveBiddingEnabled).thenReturn(false)
 
     val adUnit = mock<AdUnit>()
-    val bidListener = mock<BidListener>()
+    val bidListener = mock<CdbResponseSlotListener>()
 
     doReturn(null).whenever(bidManager).getBidForAdUnitAndPrefetch(adUnit)
 

--- a/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInternalUnitTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInternalUnitTest.java
@@ -318,14 +318,14 @@ public class CriteoInternalUnitTest {
   @Test
   public void getBidForAdUnit_GivenBidManager_DelegateToIt() throws Exception {
     AdUnit adUnit = mock(AdUnit.class);
-    BidListener bidListener = mock(BidListener.class);
+    CdbResponseSlotListener cdbResponseSlotListener = mock(CdbResponseSlotListener.class);
 
     BidManager bidManager = givenMockedBidManager();
 
     CriteoInternal criteo = createCriteo();
-    criteo.getBidForAdUnit(adUnit, bidListener);
+    criteo.getBidForAdUnit(adUnit, cdbResponseSlotListener);
 
-    verify(bidManager).getBidForAdUnit(adUnit, bidListener);
+    verify(bidManager).getBidForAdUnit(adUnit, cdbResponseSlotListener);
   }
 
   private void givenMockedUserPrivacyUtil() {

--- a/publisher-sdk/src/test/java/com/criteo/publisher/DummyCriteoTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/DummyCriteoTest.java
@@ -66,12 +66,12 @@ public class DummyCriteoTest {
 
   @Test
   public void getBidForAdUnit_GivenAnyAdUnit_ReturnNull() throws Exception {
-    BidListener bidListener = Mockito.mock(BidListener.class);
-    criteo.getBidForAdUnit(null, bidListener);
-    criteo.getBidForAdUnit(banner, bidListener);
-    criteo.getBidForAdUnit(interstitial, bidListener);
-    criteo.getBidForAdUnit(aNative, bidListener);
-    Mockito.verify(bidListener, times(4)).onNoBid();
+    CdbResponseSlotListener cdbResponseSlotListener = Mockito.mock(CdbResponseSlotListener.class);
+    criteo.getBidForAdUnit(null, cdbResponseSlotListener);
+    criteo.getBidForAdUnit(banner, cdbResponseSlotListener);
+    criteo.getBidForAdUnit(interstitial, cdbResponseSlotListener);
+    criteo.getBidForAdUnit(aNative, cdbResponseSlotListener);
+    Mockito.verify(cdbResponseSlotListener, times(4)).onNoBid();
   }
 
   @Test

--- a/publisher-sdk/src/test/java/com/criteo/publisher/LiveCdbCallListenerTests.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/LiveCdbCallListenerTests.kt
@@ -35,7 +35,7 @@ import java.lang.Exception
 
 class LiveCdbCallListenerTests {
   @Mock
-  private lateinit var bidListener: BidListener
+  private lateinit var cdbResponseSlotListener: CdbResponseSlotListener
 
   @Mock
   private lateinit var bidManager: BidManager
@@ -77,8 +77,8 @@ class LiveCdbCallListenerTests {
 
     verify(bidManager).setTimeToNextCall(1_000)
     verify(bidManager, never()).setCacheAdUnits(any())
-    verify(bidListener, never()).onNoBid()
-    verify(bidListener, times(1)).onBidResponse(freshCdbResponseSlot)
+    verify(cdbResponseSlotListener, never()).onNoBid()
+    verify(cdbResponseSlotListener, times(1)).onBidResponse(freshCdbResponseSlot)
     verify(bidLifecycleListener).onCdbCallFinished(cdbRequest, cdbResponse)
     verify(bidLifecycleListener).onBidConsumed(cacheAdUnit, freshCdbResponseSlot);
   }
@@ -94,8 +94,8 @@ class LiveCdbCallListenerTests {
 
     verify(bidManager).setTimeToNextCall(1_000)
     verify(bidManager, never()).setCacheAdUnits(any())
-    verify(bidListener).onNoBid()
-    verify(bidListener, never()).onBidResponse(freshCdbResponseSlot)
+    verify(cdbResponseSlotListener).onNoBid()
+    verify(cdbResponseSlotListener, never()).onBidResponse(freshCdbResponseSlot)
     verify(bidLifecycleListener, never()).onBidConsumed(cacheAdUnit, freshCdbResponseSlot)
     verify(bidLifecycleListener).onCdbCallFinished(cdbRequest, cdbResponse)
   }
@@ -110,8 +110,8 @@ class LiveCdbCallListenerTests {
 
     verify(bidManager).setTimeToNextCall(1_000)
     verify(bidManager, never()).setCacheAdUnits(any())
-    verify(bidListener, never()).onBidResponse(any())
-    verify(bidListener).onNoBid()
+    verify(cdbResponseSlotListener, never()).onBidResponse(any())
+    verify(cdbResponseSlotListener).onNoBid()
     verify(bidLifecycleListener).onCdbCallFinished(cdbRequest, cdbResponse)
   }
 
@@ -125,9 +125,9 @@ class LiveCdbCallListenerTests {
 
     verify(bidManager).setTimeToNextCall(1_000)
     verify(bidLifecycleListener).onCdbCallFinished(cdbRequest, cdbResponse)
-    verify(bidListener, never()).onBidResponse(any())
+    verify(cdbResponseSlotListener, never()).onBidResponse(any())
     verify(bidManager).setCacheAdUnits(listOf(freshCdbResponseSlot))
-    verify(bidListener).onNoBid()
+    verify(cdbResponseSlotListener).onNoBid()
   }
 
   @Test
@@ -142,9 +142,9 @@ class LiveCdbCallListenerTests {
     verify(bidManager).setTimeToNextCall(1_000)
     verify(bidManager).consumeCachedBid(cacheAdUnit)
     verify(bidManager).setCacheAdUnits(cdbResponse.slots)
-    verify(bidListener).onBidResponse(cachedCdbResponseSlot)
-    verify(bidListener, never()).onBidResponse(freshCdbResponseSlot)
-    verify(bidListener, never()).onNoBid()
+    verify(cdbResponseSlotListener).onBidResponse(cachedCdbResponseSlot)
+    verify(cdbResponseSlotListener, never()).onBidResponse(freshCdbResponseSlot)
+    verify(cdbResponseSlotListener, never()).onNoBid()
     verify(bidLifecycleListener).onCdbCallFinished(cdbRequest, cdbResponse)
     verify(bidLifecycleListener).onBidConsumed(cacheAdUnit, cachedCdbResponseSlot)
   }
@@ -164,9 +164,9 @@ class LiveCdbCallListenerTests {
     verify(bidManager).consumeCachedBid(cacheAdUnit)
     verify(bidManager).setTimeToNextCall(1_000)
     verify(bidManager).setCacheAdUnits(cdbResponse.slots)
-    verify(bidListener, never()).onBidResponse(cachedCdbResponseSlot)
-    verify(bidListener, never()).onBidResponse(freshCdbResponseSlot)
-    verify(bidListener).onNoBid()
+    verify(cdbResponseSlotListener, never()).onBidResponse(cachedCdbResponseSlot)
+    verify(cdbResponseSlotListener, never()).onBidResponse(freshCdbResponseSlot)
+    verify(cdbResponseSlotListener).onNoBid()
     verify(bidLifecycleListener).onCdbCallFinished(cdbRequest, cdbResponse)
     verify(bidLifecycleListener).onBidConsumed(any(), any())
   }
@@ -183,9 +183,9 @@ class LiveCdbCallListenerTests {
     verify(bidManager).consumeCachedBid(cacheAdUnit)
     verify(bidManager).setTimeToNextCall(1_000)
     verify(bidManager).setCacheAdUnits(cdbResponse.slots)
-    verify(bidListener, never()).onBidResponse(cachedCdbResponseSlot)
-    verify(bidListener, never()).onBidResponse(freshCdbResponseSlot)
-    verify(bidListener).onNoBid()
+    verify(cdbResponseSlotListener, never()).onBidResponse(cachedCdbResponseSlot)
+    verify(cdbResponseSlotListener, never()).onBidResponse(freshCdbResponseSlot)
+    verify(cdbResponseSlotListener).onNoBid()
     verify(bidLifecycleListener).onCdbCallFinished(cdbRequest, cdbResponse)
     verify(bidLifecycleListener, never()).onBidConsumed(any(), any())
   }
@@ -203,8 +203,8 @@ class LiveCdbCallListenerTests {
     verify(bidManager).consumeCachedBid(cacheAdUnit)
     verify(bidManager, never()).setTimeToNextCall(1_000)
     verify(bidManager, never()).setCacheAdUnits(any())
-    verify(bidListener, never()).onBidResponse(any())
-    verify(bidListener, times(1)).onNoBid()
+    verify(cdbResponseSlotListener, never()).onBidResponse(any())
+    verify(cdbResponseSlotListener, times(1)).onNoBid()
     verify(bidLifecycleListener, never()).onCdbCallFinished(cdbRequest, cdbResponse)
     verify(bidLifecycleListener).onCdbCallFailed(cdbRequest, exception)
     verify(bidLifecycleListener, never()).onBidConsumed(any(), any())
@@ -224,8 +224,8 @@ class LiveCdbCallListenerTests {
     verify(bidManager, never()).consumeCachedBid(cacheAdUnit)
     verify(bidManager, never()).setTimeToNextCall(1_000)
     verify(bidManager, never()).setCacheAdUnits(any())
-    verify(bidListener, never()).onBidResponse(any())
-    verify(bidListener, times(1)).onNoBid()
+    verify(cdbResponseSlotListener, never()).onBidResponse(any())
+    verify(cdbResponseSlotListener, times(1)).onNoBid()
 
     verify(bidLifecycleListener, never()).onCdbCallFinished(cdbRequest, cdbResponse)
     verify(bidLifecycleListener, never()).onBidConsumed(any(), any())

--- a/publisher-sdk/src/test/java/com/criteo/publisher/advancednative/CriteoNativeLoaderTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/advancednative/CriteoNativeLoaderTest.kt
@@ -16,7 +16,7 @@
 
 package com.criteo.publisher.advancednative
 
-import com.criteo.publisher.BidListener
+import com.criteo.publisher.CdbResponseSlotListener
 import com.criteo.publisher.BidManager
 import com.criteo.publisher.CriteoErrorCode
 import com.criteo.publisher.InHouse
@@ -235,7 +235,7 @@ class CriteoNativeLoaderTest(private val liveBiddingEnabled: Boolean) {
       doReturn(null).whenever(mock).getBidForAdUnitAndPrefetch(adUnit)
 
       doAnswer {
-        it.getArgument<BidListener>(1).onNoBid()
+        it.getArgument<CdbResponseSlotListener>(1).onNoBid()
       }.whenever(mock).getLiveBidForAdUnit(eq(adUnit), any())
     }
   }
@@ -251,7 +251,7 @@ class CriteoNativeLoaderTest(private val liveBiddingEnabled: Boolean) {
       doReturn(slot).whenever(mock).getBidForAdUnitAndPrefetch(adUnit)
 
       doAnswer {
-        it.getArgument<BidListener>(1).onBidResponse(slot)
+        it.getArgument<CdbResponseSlotListener>(1).onBidResponse(slot)
       }.whenever(mock).getLiveBidForAdUnit(eq(adUnit), any())
     }
 
@@ -270,7 +270,7 @@ class CriteoNativeLoaderTest(private val liveBiddingEnabled: Boolean) {
       doReturn(slot).whenever(mock).getBidForAdUnitAndPrefetch(adUnit)
 
       doAnswer {
-        it.getArgument<BidListener>(1).onBidResponse(slot)
+        it.getArgument<CdbResponseSlotListener>(1).onBidResponse(slot)
       }.whenever(mock).getLiveBidForAdUnit(eq(adUnit), any())
     }
   }


### PR DESCRIPTION
A listener, that will be part of the public API, will be needed for
supporting live-bidding in InHouse and HeaderBidding integrations. This
listener will be used by publishers to trigger an action once a bid is
fetched asynchronously.

`BidListener` will be a good candidate for such public API, and to avoid
any confusion the current `BidListener` is renamed into a
`CdbResponseSlotListener`.