### PR TITLE
Support dependency provider with lambda capturing "this"

### DIFF
--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -26,9 +26,21 @@ plugins {
 
 androidLibModule()
 
+android {
+  defaultConfig {
+    multiDexEnabled = true
+  }
+
+  packagingOptions {
+    // Both AssertJ and ByteBuddy (via Mockito) bring this and the duplication yields an error
+    exclude("META-INF/licenses/ASM")
+  }
+}
+
 dependencies {
   compileOnly(project(":publisher-sdk"))
 
+  implementation(Deps.AndroidX.MultiDex)
   implementation(Deps.JUnit.JUnit)
   implementation(Deps.Square.OkHttp.MockWebServer)
   compileOnly(Deps.AutoValue.GsonRuntime)
@@ -50,6 +62,8 @@ dependencies {
 
   androidTestImplementation(Deps.AndroidX.Test.Runner)
   androidTestImplementation(Deps.AssertJ.AssertJ)
+  androidTestImplementation(Deps.Mockito.Android)
+  androidTestImplementation(Deps.Mockito.Kotlin)
 
   detektPlugins(Deps.Detekt.DetektFormatting)
 }

--- a/test-utils/src/androidTest/java/com/criteo/publisher/mock/DependenciesAnnotationInjectionAndroidTest.kt
+++ b/test-utils/src/androidTest/java/com/criteo/publisher/mock/DependenciesAnnotationInjectionAndroidTest.kt
@@ -1,0 +1,50 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.criteo.publisher.mock
+
+import com.nhaarman.mockitokotlin2.spy
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.Test
+
+class DependenciesAnnotationInjectionAndroidTest {
+
+  /**
+   * When a lambda is capturing only `this`, then a new method is created:
+   * - method is synthetic
+   * - method has no argument
+   * - method returns what the lambda returns
+   *
+   * For [javax.inject.Inject] objects, the [DependenciesAnnotationInjection] is looking for methods without argument
+   * and returning the expected type. So the generated lambda method is a matching candidate.
+   * Unless the injection check candidate methods are not synthetic.
+   *
+   * Note that this is only observable on Android: the Android SDK is generating such method during compilation while
+   * the JDK is only placing an invoke dynamic at call-site which will lazily generate and call a SAM during runtime
+   * (via its [java.lang.invoke.LambdaMetafactory]).
+   * The difference is that JDK has no effect on callers while Android has.
+   */
+  @Test
+  fun processInject_GivenJavaDependencyProviderWithLambdaCapturingThis_DoNotThrow() {
+    val dependencyProvider = spy(JavaDummyDependencyProvider())
+    val dummyTest = JavaDummyDependencyProvider.JavaDummyTest()
+
+    val injection = DependenciesAnnotationInjection(dependencyProvider)
+
+    assertThatCode {
+      injection.process(dummyTest)
+    }.doesNotThrowAnyException()
+  }
+}

--- a/test-utils/src/androidTest/java/com/criteo/publisher/mock/JavaDummyDependencyProvider.java
+++ b/test-utils/src/androidTest/java/com/criteo/publisher/mock/JavaDummyDependencyProvider.java
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher.mock;
+
+import androidx.annotation.NonNull;
+import java.util.function.Supplier;
+import javax.inject.Inject;
+
+@SuppressWarnings("unused")
+class JavaDummyDependencyProvider {
+
+  @NonNull
+  public DummyDependency provideDummyDependencyWithLambdaCapturingThis() {
+    // See DependenciesAnnotationInjectionAndroidTest#processInject_GivenJavaDependencyProviderWithLambdaCapturingThis_DoNotThrow
+    Supplier<DummyDependency> supplier = () -> new DummyDependency(this);
+    return supplier.get();
+  }
+
+  static class JavaDummyTest {
+
+    @Inject
+    private DummyDependency dummyDependency;
+  }
+
+  static class DummyDependency {
+
+    DummyDependency(JavaDummyDependencyProvider ignored) {
+    }
+  }
+}


### PR DESCRIPTION
As we're moving forward on Java 8 feature, lambdas will appear in the
dependency provider. Currently the DependenciesAnnotationInjection does
not handled method generated by Android compiler when a lambda is
capturing `this`.

This is fixed by ignoring synthetic methods. Synthetic elements are the
elements added by a Java compiler but without any trace in the source
code. Hence it is legitimate to ignore such methods.