### PR TITLE
Make CriteoBannerView a custom view class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   https://developer.android.com/studio/write/java8-support.
   - Remove the deprecated `Criteo#init` method. [`Criteo.Builder#init`](https://github.com/criteo/android-publisher-sdk/blob/main/publisher-sdk/src/main/java/com/criteo/publisher/Criteo.java#L54)
   should be used instead.
+- CriteoBannerView is now a custom view that can included directly in a layout file.
 
 # Version 3.10.1
 - Bug fix

--- a/app/src/main/java/com/criteo/testapp/InHouseActivity.java
+++ b/app/src/main/java/com/criteo/testapp/InHouseActivity.java
@@ -19,11 +19,10 @@ package com.criteo.testapp;
 import static com.criteo.testapp.PubSdkDemoApplication.INTERSTITIAL_IBV_DEMO;
 import static com.criteo.testapp.PubSdkDemoApplication.NATIVE;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Button;
-import android.widget.LinearLayout;
+import android.widget.FrameLayout;
 import androidx.appcompat.app.AppCompatActivity;
 import com.criteo.publisher.Criteo;
 import com.criteo.publisher.CriteoBannerView;
@@ -47,11 +46,11 @@ public class InHouseActivity extends AppCompatActivity {
 
   public static final BannerAdUnit BANNER = new BannerAdUnit(
       "/140800857/Endeavour_320x50",
-      new AdSize(320, 50));
+      new AdSize(320, 50)
+  );
 
-  private Context context;
-  private LinearLayout adLayout;
   private CriteoBannerView criteoBannerView;
+  private FrameLayout nativeAdContainer;
   private CriteoNativeLoader nativeLoader;
   private Button btnShowInterstitial;
   private Button btnShowInterstitialIbv;
@@ -62,14 +61,17 @@ public class InHouseActivity extends AppCompatActivity {
     setContentView(R.layout.activity_in_house);
     MockedIntegrationRegistry.force(Integration.IN_HOUSE);
 
-    adLayout = findViewById(R.id.AdLayout);
+    criteoBannerView = findViewById(R.id.criteoBannerView);
+    nativeAdContainer = findViewById(R.id.nativeAdContainer);
+    criteoBannerView.setCriteoBannerAdListener(new TestAppBannerAdListener(
+        TAG, "In-House"));
+
     btnShowInterstitial = findViewById(R.id.buttonInhouseInterstitial);
     btnShowInterstitialIbv = findViewById(R.id.buttonInhouseInterstitialIbv);
-    context = getApplicationContext();
 
     nativeLoader = new CriteoNativeLoader(
         NATIVE,
-        new TestAppNativeAdListener(TAG, NATIVE.getAdUnitId(), adLayout),
+        new TestAppNativeAdListener(TAG, NATIVE.getAdUnitId(), nativeAdContainer),
         new TestAppNativeRenderer()
     );
 
@@ -101,14 +103,6 @@ public class InHouseActivity extends AppCompatActivity {
   }
 
   private void loadBannerAd() {
-    if (criteoBannerView != null) {
-      criteoBannerView.destroy();
-    }
-
-    criteoBannerView = new CriteoBannerView(context);
-    criteoBannerView.setCriteoBannerAdListener(new TestAppBannerAdListener(
-        TAG, "In-House", adLayout));
-
     Log.d(TAG, "Banner Requested");
     Criteo.getInstance().loadBid(BANNER, criteoBannerView::loadAd);
   }

--- a/app/src/main/java/com/criteo/testapp/StandaloneActivity.java
+++ b/app/src/main/java/com/criteo/testapp/StandaloneActivity.java
@@ -18,13 +18,11 @@ package com.criteo.testapp;
 
 import static com.criteo.testapp.PubSdkDemoApplication.INTERSTITIAL_IBV_DEMO;
 import static com.criteo.testapp.PubSdkDemoApplication.NATIVE;
-import static com.criteo.testapp.PubSdkDemoApplication.STANDALONE_BANNER;
 
-import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import android.widget.Button;
-import android.widget.LinearLayout;
+import android.widget.FrameLayout;
 import androidx.appcompat.app.AppCompatActivity;
 import com.criteo.publisher.CriteoBannerView;
 import com.criteo.publisher.CriteoInterstitial;
@@ -44,12 +42,11 @@ public class StandaloneActivity extends AppCompatActivity {
   private static final InterstitialAdUnit INTERSTITIAL = new InterstitialAdUnit(
       "/140800857/Endeavour_Interstitial_320x480");
 
-  private Context context;
-  private LinearLayout adLayout;
   private CriteoBannerView criteoBannerView;
   private CriteoNativeLoader nativeLoader;
   private Button btnShowInterstitial;
   private Button btnShowInterstitialIbv;
+  private FrameLayout nativeAdContainer;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -57,20 +54,27 @@ public class StandaloneActivity extends AppCompatActivity {
     setContentView(R.layout.activity_stand_alone);
     MockedIntegrationRegistry.force(Integration.STANDALONE);
 
-    adLayout = findViewById(R.id.AdLayout);
     btnShowInterstitial = findViewById(R.id.buttonStandAloneInterstitial);
     btnShowInterstitialIbv = findViewById(R.id.buttonStandAloneInterstitialIbv);
+    criteoBannerView = findViewById(R.id.criteoBannerView);
+    nativeAdContainer = findViewById(R.id.nativeAdContainer);
 
-    context = getApplicationContext();
+    criteoBannerView.setCriteoBannerAdListener(new TestAppBannerAdListener(
+        TAG, "Standalone"));
 
     nativeLoader = new CriteoNativeLoader(
         NATIVE,
-        new TestAppNativeAdListener(TAG, NATIVE.getAdUnitId(), adLayout),
+        new TestAppNativeAdListener(TAG, NATIVE.getAdUnitId(), nativeAdContainer),
         new TestAppNativeRenderer()
     );
 
-    findViewById(R.id.buttonStandAloneBanner).setOnClickListener(v -> loadBanner());
+    findViewById(R.id.buttonStandAloneBanner).setOnClickListener(v -> loadBannerAd());
     findViewById(R.id.buttonStandAloneNative).setOnClickListener(v -> loadNative());
+  }
+
+  private void loadBannerAd() {
+    Log.d(TAG, "Banner Requested");
+    criteoBannerView.loadAd();
   }
 
   @Override
@@ -94,19 +98,6 @@ public class StandaloneActivity extends AppCompatActivity {
     if (interstitial.isAdLoaded()) {
       interstitial.show();
     }
-  }
-
-  private void loadBanner() {
-    if (criteoBannerView != null) {
-      criteoBannerView.destroy();
-    }
-
-    criteoBannerView = new CriteoBannerView(context, STANDALONE_BANNER);
-    criteoBannerView.setCriteoBannerAdListener(new TestAppBannerAdListener(
-        TAG, "Standalone", adLayout));
-
-    Log.d(TAG, "Banner Requested");
-    criteoBannerView.loadAd();
   }
 
   private void loadNative() {

--- a/app/src/main/java/com/criteo/testapp/StandaloneRecyclerViewActivity.kt
+++ b/app/src/main/java/com/criteo/testapp/StandaloneRecyclerViewActivity.kt
@@ -77,7 +77,7 @@ class StandaloneRecyclerViewActivity : AppCompatActivity() {
 
   private fun loadBanner(adapter: Adapter) {
     val bannerView = CriteoBannerView(baseContext, STANDALONE_BANNER)
-    bannerView.setCriteoBannerAdListener(object : TestAppBannerAdListener(javaClass.simpleName, "Banner", null) {
+    bannerView.setCriteoBannerAdListener(object : TestAppBannerAdListener(javaClass.simpleName, "Banner") {
       override fun onAdReceived(view: View?) {
         adapter.addBannerAd(bannerView)
       }

--- a/app/src/main/java/com/criteo/testapp/listener/TestAppBannerAdListener.java
+++ b/app/src/main/java/com/criteo/testapp/listener/TestAppBannerAdListener.java
@@ -18,7 +18,6 @@ package com.criteo.testapp.listener;
 
 import android.util.Log;
 import android.view.View;
-import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import com.criteo.publisher.CriteoBannerAdListener;
 import com.criteo.publisher.CriteoErrorCode;
@@ -27,12 +26,10 @@ public class TestAppBannerAdListener implements CriteoBannerAdListener {
 
   private final String tag;
   private final String prefix;
-  private final ViewGroup adLayout;
 
-  public TestAppBannerAdListener(String tag, String prefix, ViewGroup adLayout) {
+  public TestAppBannerAdListener(String tag, String prefix) {
     this.tag = tag;
     this.prefix = prefix;
-    this.adLayout = adLayout;
   }
 
   @Override
@@ -63,9 +60,6 @@ public class TestAppBannerAdListener implements CriteoBannerAdListener {
   @Override
   public void onAdReceived(View view) {
     Log.d(tag, prefix + " - Banner onAdReceived");
-
-    adLayout.removeAllViews();
-    adLayout.addView(view);
   }
 
 }

--- a/app/src/main/java/com/criteo/testapp/listener/TestAppNativeAdListener.java
+++ b/app/src/main/java/com/criteo/testapp/listener/TestAppNativeAdListener.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.criteo.publisher.CriteoErrorCode;
 import com.criteo.publisher.advancednative.CriteoNativeAd;
 import com.criteo.publisher.advancednative.CriteoNativeAdListener;
@@ -30,7 +31,7 @@ public class TestAppNativeAdListener extends CriteoNativeAdListener {
   private final String prefix;
   private final ViewGroup adLayout;
 
-  public TestAppNativeAdListener(String tag, String prefix, ViewGroup adLayout) {
+  public TestAppNativeAdListener(String tag, String prefix, @Nullable ViewGroup adLayout) {
     this.tag = tag;
     this.prefix = prefix;
     this.adLayout = adLayout;
@@ -39,7 +40,6 @@ public class TestAppNativeAdListener extends CriteoNativeAdListener {
   @Override
   public void onAdReceived(@NonNull CriteoNativeAd nativeAd) {
     Log.d(tag, prefix + " - Native onAdReceived");
-
     View view = nativeAd.createNativeRenderedView(adLayout.getContext(), adLayout);
     adLayout.removeAllViews();
     adLayout.addView(view);

--- a/app/src/main/res/layout/activity_in_house.xml
+++ b/app/src/main/res/layout/activity_in_house.xml
@@ -2,7 +2,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  xmlns:ndroid="http://schemas.android.com/tools">
+  xmlns:ndroid="http://schemas.android.com/tools"
+  xmlns:app="http://schemas.android.com/apk/res-auto">
 
   <LinearLayout
     android:layout_width="match_parent"
@@ -60,12 +61,27 @@
           android:text="@string/btn_advanced_native"/>
       </LinearLayout>
     </HorizontalScrollView>
-    <LinearLayout
-      android:id="@+id/AdLayout"
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:layout_marginTop="10dp"
-      android:orientation="vertical">
-    </LinearLayout>
+      >
+      <com.criteo.publisher.CriteoBannerView
+        android:id="@+id/criteoBannerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:criteoAdUnitHeight="50"
+        app:criteoAdUnitWidth="320"
+        app:criteoAdUnitId="/140800857/Endeavour_320x50"
+        app:layout_constraintStart_toStartOf="parent"
+        />
+      <FrameLayout
+        android:id="@+id/nativeAdContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/criteoBannerView"
+        android:layout_marginTop="64dp"
+        />
+    </androidx.constraintlayout.widget.ConstraintLayout>
   </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_stand_alone.xml
+++ b/app/src/main/res/layout/activity_stand_alone.xml
@@ -29,7 +29,7 @@
           android:layout_weight="1"
           android:background="@android:color/holo_blue_dark"
           android:enabled="false"
-          android:text="@string/btn_interstitial"/>
+          android:text="@string/btn_interstitial" />
         <Button
           android:id="@+id/buttonStandAloneBanner"
           style="@style/Widget.AppCompat.Button.Colored"
@@ -39,7 +39,7 @@
           android:layout_marginStart="5dp"
           android:layout_marginLeft="5dp"
           android:background="@android:color/holo_blue_dark"
-          android:text="@string/btn_banner"/>
+          android:text="@string/btn_banner" />
         <Button
           android:id="@+id/buttonStandAloneInterstitialIbv"
           style="@style/Widget.AppCompat.Button.Colored"
@@ -50,7 +50,7 @@
           android:layout_marginLeft="5dp"
           android:background="@android:color/holo_blue_dark"
           android:enabled="false"
-          android:text="@string/btn_interstitial_ibv"/>
+          android:text="@string/btn_interstitial_ibv" />
         <Button
           android:id="@+id/buttonStandAloneNative"
           style="@style/Widget.AppCompat.Button.Colored"
@@ -60,15 +60,30 @@
           android:layout_marginStart="5dp"
           android:layout_marginLeft="5dp"
           android:background="@android:color/holo_blue_dark"
-          android:text="@string/btn_advanced_native"/>
+          android:text="@string/btn_advanced_native" />
       </LinearLayout>
     </HorizontalScrollView>
-    <LinearLayout
-      android:id="@+id/AdLayout"
+    <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:layout_marginTop="10dp"
-      android:orientation="vertical">
-    </LinearLayout>
+      >
+    <com.criteo.publisher.CriteoBannerView
+      android:id="@+id/criteoBannerView"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:criteoAdUnitHeight="50"
+      app:criteoAdUnitWidth="320"
+      app:criteoAdUnitId="/140800857/Endeavour_320x50"
+      app:layout_constraintStart_toStartOf="parent"
+      />
+    <FrameLayout
+      android:id="@+id/nativeAdContainer"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/criteoBannerView"
+      android:layout_marginTop="64dp"
+      />
+    </androidx.constraintlayout.widget.ConstraintLayout>
   </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_illegal_1.xml
+++ b/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_illegal_1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.criteo.publisher.CriteoBannerView xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  app:criteoAdUnitId="criteoAdUnitId"
+  />

--- a/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_illegal_2.xml
+++ b/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_illegal_2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.criteo.publisher.CriteoBannerView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  app:criteoAdUnitWidth="100"
+  />

--- a/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_illegal_3.xml
+++ b/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_illegal_3.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.criteo.publisher.CriteoBannerView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  app:criteoAdUnitHeight="100"
+  />

--- a/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_inhouse.xml
+++ b/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_inhouse.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.criteo.publisher.CriteoBannerView
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  />

--- a/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_standalone.xml
+++ b/publisher-sdk-tests/src/main/res/layout/test_criteo_banner_view_standalone.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.criteo.publisher.CriteoBannerView xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_height="match_parent"
+  android:layout_width="match_parent"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  app:criteoAdUnitId="criteoAdUnitId"
+  app:criteoAdUnitWidth="100"
+  app:criteoAdUnitHeight="50"
+  />

--- a/publisher-sdk-tests/src/main/res/values/attrs.xml
+++ b/publisher-sdk-tests/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="CriteoBannerView">
+    <attr name="criteoAdUnitId" format="string"/>
+    <attr name="criteoAdUnitHeight" format="integer"/>
+    <attr name="criteoAdUnitWidth" format="integer"/>
+  </declare-styleable>
+</resources>

--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/CriteoBannerViewTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/CriteoBannerViewTest.java
@@ -1,0 +1,100 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher;
+
+import static com.criteo.publisher.concurrent.ThreadingUtil.runOnMainThreadAndWait;
+import static org.assertj.core.api.Assertions.anyOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.Assert.assertEquals;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import com.criteo.publisher.mock.MockedDependenciesRule;
+import java.util.concurrent.ExecutionException;
+import javax.inject.Inject;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CriteoBannerViewTest {
+
+  @Rule
+  public MockedDependenciesRule mockedDependenciesRule = new MockedDependenciesRule();
+
+  @Inject
+  private Context context;
+
+  @Test
+  public void inflatedFromXml_GivenNoAttribute_InHouseIsSet() {
+    runOnMainThreadAndWait(() -> {
+      LayoutInflater inflater = LayoutInflater.from(context);
+
+      CriteoBannerView criteoBannerView = (CriteoBannerView) inflater
+          .inflate(com.criteo.publisher.tests.R.layout.test_criteo_banner_view_inhouse, null);
+
+      assertThat(criteoBannerView.bannerAdUnit).isNull();
+    });
+  }
+
+  @Test
+  public void inflatedFromXml_GivenAllAttributeSet_StandaloneIsSet() {
+    runOnMainThreadAndWait(() -> {
+      LayoutInflater inflater = LayoutInflater.from(context);
+
+      CriteoBannerView criteoBannerView = (CriteoBannerView) inflater
+          .inflate(com.criteo.publisher.tests.R.layout.test_criteo_banner_view_standalone, null);
+
+      assertThat( criteoBannerView.bannerAdUnit.getSize().getWidth()).isEqualTo(100);
+      assertThat(criteoBannerView.bannerAdUnit.getSize().getHeight()).isEqualTo(50);
+      assertEquals("criteoAdUnitId", criteoBannerView.bannerAdUnit.getAdUnitId());
+      assertThat(criteoBannerView.bannerAdUnit.getAdUnitId()).isEqualTo("criteoAdUnitId");
+    });
+  }
+
+  @Test
+  public void inflatedFromXml_GivenAdUnitIdIsOnlySet_ThenThrow() {
+    assertThatCode(() -> runOnMainThreadAndWait(() -> {
+      LayoutInflater inflater = LayoutInflater.from(context);
+      inflater.inflate(
+          com.criteo.publisher.tests.R.layout.test_criteo_banner_view_illegal_1,
+          null
+      );
+    })).hasCauseInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void inflatedFromXml_GivenAdUnitWidthIsOnlySet_ThenThrow() {
+    assertThatCode(() -> runOnMainThreadAndWait(() -> {
+      LayoutInflater inflater = LayoutInflater.from(context);
+      inflater.inflate(
+          com.criteo.publisher.tests.R.layout.test_criteo_banner_view_illegal_2,
+          null
+      );
+    })).hasCauseInstanceOf(ExecutionException.class);
+  }
+
+  @Test
+  public void inflatedFromXml_GivenAdUnitHeightIsOnlySet_ThenThrow() {
+    assertThatCode(() -> runOnMainThreadAndWait(() -> {
+      LayoutInflater inflater = LayoutInflater.from(context);
+      inflater.inflate(
+          com.criteo.publisher.tests.R.layout.test_criteo_banner_view_illegal_3,
+          null
+      );
+    })).hasCauseInstanceOf(ExecutionException.class);
+  }
+}

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
@@ -135,7 +135,7 @@ final class CriteoInternal extends Criteo {
    * Method to start new CdbDownload Asynctask [Standalone only]
    */
   @Override
-  void getBidForAdUnit(AdUnit adUnit, @NonNull BidListener bidListener) {
+  void getBidForAdUnit(@Nullable AdUnit adUnit, @NonNull BidListener bidListener) {
     bidManager.getBidForAdUnit(adUnit, bidListener);
   }
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/Logger.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/Logger.java
@@ -48,6 +48,14 @@ public class Logger {
     log(Log.DEBUG, message, args, null);
   }
 
+  public void info(String message, Throwable thrown) {
+    log(Log.INFO, message, EMPTY, thrown);
+  }
+
+  public void info(String message, Object... args) {
+    log(Log.INFO, message, args, null);
+  }
+
   public void error(Throwable thrown) {
     log(Log.ERROR, null, EMPTY, thrown);
   }

--- a/publisher-sdk/src/main/res/values/attrs.xml
+++ b/publisher-sdk/src/main/res/values/attrs.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="CriteoBannerView">
+    <attr name="criteoAdUnitId" format="string"/>
+    <attr name="criteoAdUnitHeight" format="integer"/>
+    <attr name="criteoAdUnitWidth" format="integer"/>
+  </declare-styleable>
+</resources>

--- a/publisher-sdk/src/test/java/com/criteo/publisher/logging/LoggerTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/logging/LoggerTest.kt
@@ -69,6 +69,41 @@ class LoggerTest {
   }
 
   @Test
+  fun info_GivenMessageAndThrowable_PrintMessageThenStacktrace() {
+    whenever(buildConfigWrapper.minLogLevel).doReturn(Log.INFO)
+    val logger = spy(Logger(javaClass, buildConfigWrapper))
+
+    logger.info("Hello", Exception())
+
+    inOrder(logger) {
+      verify(logger).println(Log.INFO, "Hello")
+      verify(logger).println(eq(Log.INFO), anyOrNull())
+      verifyNoMoreInteractions()
+    }
+  }
+
+  @Test
+  fun info_GivenMessageAndArgs_PrintFormattedMessage() {
+    whenever(buildConfigWrapper.minLogLevel).doReturn(Log.INFO)
+    val logger = spy(Logger(javaClass, buildConfigWrapper))
+
+    logger.info("Hello %s", "World")
+
+    verify(logger).println(Log.INFO, "Hello World")
+  }
+
+
+  @Test
+  fun info_GivenMinLogLevelHigherThanInfo_IgnoreLog() {
+    whenever(buildConfigWrapper.minLogLevel).doReturn(Log.WARN)
+    val logger = spy(Logger(javaClass, buildConfigWrapper))
+
+    logger.info("Hello")
+
+    verify(logger, never()).println(any(), any())
+  }
+
+  @Test
   fun error_GivenJustThrowable_PrintStacktrace() {
     whenever(buildConfigWrapper.minLogLevel).doReturn(Log.ERROR)
     val logger = spy(Logger(javaClass, buildConfigWrapper))


### PR DESCRIPTION
In order to use `CriteoBannerView`, publishers have to instantiate it by
hand and add it to a parent layout programmatically. This is both
inefficient as it creates an unnecessary depth in the view tree, and
tedious.

By turning `CriteoBannerView` into a custom view, publishers will be
able to define it in the layout XML file directly.