### PR TITLE
Keep AdUnit interface unmangled and not internal

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/BidResponseListener.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/BidResponseListener.java
@@ -19,6 +19,7 @@ package com.criteo.publisher;
 import androidx.annotation.Keep;
 import androidx.annotation.Nullable;
 import com.criteo.publisher.advancednative.CriteoNativeLoader;
+import com.criteo.publisher.model.AdUnit;
 
 @Keep
 public interface BidResponseListener {
@@ -37,7 +38,7 @@ public interface BidResponseListener {
    *   <li>{@link CriteoNativeLoader#loadAd(Bid)}: display a native ad</li>
    * </ul>
    * <p>
-   * Please note that the <code>loadAd</code> method should match the kind of Ad the bid was asked for.
+   * Please note that the <code>loadAd</code> method should match the kind of {@link AdUnit} the bid was asked for.
    *
    * @param bid <code>null</code> in case of no bid, or a bid object that can be used to display an Ad
    * @see <a href="https://publisherdocs.criteotilt.com/app/android/app-bidding/inhouse/">InHouse documentation</a>

--- a/publisher-sdk/src/main/java/com/criteo/publisher/model/AdUnit.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/model/AdUnit.kt
@@ -15,9 +15,11 @@
  */
 package com.criteo.publisher.model
 
+import androidx.annotation.Keep
 import com.criteo.publisher.util.AdUnitType
 
-internal interface AdUnit {
+@Keep
+interface AdUnit {
   val adUnitId: String
   val adUnitType: AdUnitType
 }


### PR DESCRIPTION
`AdUnit` is used during SDK init:
```
public Builder adUnits(@Nullable List<AdUnit> adUnits);
```

So it should stay public for publishers.