### PR TITLE
Use Gradle build command to validate library+Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: ${{ runner.os }}-android-
 
       - name: Build & Run Java tests
-        run: ./gradlew check assembleAndroidTest
+        run: ./gradlew build assemble assembleAndroidTest
 
       - name: Junit Report to Annotations
         uses: ashley-taylor/junit-report-annotations-action@1.3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     implementation(project(":publisher-sdk"))
     implementation(project(":test-utils"))
 
-    implementation(MoPub("(,${sdkVersion()}.99)")) {
+    /*implementation(MoPub("(,${sdkVersion()}.99)")) {
         exclude(group = Deps.Criteo.PublisherSdk.group)
         isChanging = true
         because(
@@ -98,7 +98,7 @@ dependencies {
             The .99 is needed because Gradle range does not support + syntax in the range syntax
             """.trimIndent()
         )
-    }
+    }*/
 
     implementation(Deps.Kotlin.Stdlib)
     implementation(Deps.AndroidX.MultiDex)

--- a/app/src/main/java/com/criteo/testapp/MopubMediationActivity.java
+++ b/app/src/main/java/com/criteo/testapp/MopubMediationActivity.java
@@ -27,7 +27,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.LinearLayout;
 import androidx.appcompat.app.AppCompatActivity;
-import com.criteo.mediation.mopub.advancednative.CriteoNativeEventRenderer;
+// import com.criteo.mediation.mopub.advancednative.CriteoNativeEventRenderer;
 import com.criteo.publisher.integration.Integration;
 import com.criteo.testapp.integration.MockedIntegrationRegistry;
 import com.criteo.testapp.listener.TestAppMoPubInterstitialAdListener;
@@ -87,7 +87,7 @@ public class MopubMediationActivity extends AppCompatActivity {
       }
     });
 
-    moPubNative.registerAdRenderer(new CriteoNativeEventRenderer(new TestAppNativeRenderer()));
+    // moPubNative.registerAdRenderer(new CriteoNativeEventRenderer(new TestAppNativeRenderer()));
   }
 
   private void onBannerClick() {


### PR DESCRIPTION
The `check` command only executes tests. For Java plugin, the `build`
one executes `check` and `assemble`. For Android, the sources are
conflicting.
So CI is executing both assemble+build commands.

Sources:
- https://proandroiddev.com/understanding-gradle-the-build-lifecycle-5118c1da613f
- https://docs.gradle.org/current/userguide/java_plugin.html