### PR TITLE
Simplify loading of interstitials in test app

### DIFF
--- a/app/src/main/java/com/criteo/testapp/InHouseActivity.java
+++ b/app/src/main/java/com/criteo/testapp/InHouseActivity.java
@@ -23,7 +23,6 @@ import static com.criteo.testapp.PubSdkDemoApplication.NATIVE;
 
 import android.os.Bundle;
 import android.util.Log;
-import android.widget.Button;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
@@ -48,8 +47,6 @@ public class InHouseActivity extends AppCompatActivity {
   private CriteoBannerView criteoBannerView;
   private FrameLayout nativeAdContainer;
   private CriteoNativeLoader nativeLoader;
-  private Button btnShowInterstitial;
-  private Button btnShowInterstitialIbv;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -62,9 +59,6 @@ public class InHouseActivity extends AppCompatActivity {
     criteoBannerView.setCriteoBannerAdListener(new TestAppBannerAdListener(
         TAG, "In-House"));
 
-    btnShowInterstitial = findViewById(R.id.buttonInhouseInterstitial);
-    btnShowInterstitialIbv = findViewById(R.id.buttonInhouseInterstitialIbv);
-
     nativeLoader = new CriteoNativeLoader(
         NATIVE,
         new TestAppNativeAdListener(TAG, NATIVE.getAdUnitId(), nativeAdContainer),
@@ -73,6 +67,8 @@ public class InHouseActivity extends AppCompatActivity {
 
     findViewById(R.id.buttonInhouseBanner).setOnClickListener(v -> loadBannerAd());
     findViewById(R.id.buttonInhouseNative).setOnClickListener(v -> loadNative());
+    findViewById(R.id.buttonInhouseInterstitial).setOnClickListener(v -> loadInterstitial(INTERSTITIAL));
+    findViewById(R.id.buttonInhouseInterstitialIbv).setOnClickListener(v -> loadInterstitial(INTERSTITIAL_IBV_DEMO));
   }
 
   @Override
@@ -80,21 +76,6 @@ public class InHouseActivity extends AppCompatActivity {
     super.onDestroy();
     if (criteoBannerView != null) {
       criteoBannerView.destroy();
-    }
-  }
-
-  @Override
-  protected void onResume() {
-    super.onResume();
-    btnShowInterstitial.setEnabled(false);
-    btnShowInterstitialIbv.setEnabled(false);
-    loadInterstitialAd(INTERSTITIAL, btnShowInterstitial);
-    loadInterstitialAd(INTERSTITIAL_IBV_DEMO, btnShowInterstitialIbv);
-  }
-
-  private void showInterstitial(CriteoInterstitial interstitial) {
-    if (interstitial.isAdLoaded()) {
-      interstitial.show();
     }
   }
 
@@ -107,17 +88,14 @@ public class InHouseActivity extends AppCompatActivity {
     Criteo.getInstance().loadBid(NATIVE, loadAd(nativeLoader, CriteoNativeLoader::loadAd));
   }
 
-  private void loadInterstitialAd(InterstitialAdUnit adUnit, Button btnShow) {
+  private void loadInterstitial(InterstitialAdUnit adUnit) {
     String prefix = "In-House " + adUnit.getAdUnitId();
 
-    CriteoInterstitial interstitial = new CriteoInterstitial();
-    interstitial.setCriteoInterstitialAdListener(
-        new TestAppInterstitialAdListener(TAG, prefix, btnShow));
+    CriteoInterstitial interstitial = new CriteoInterstitial(adUnit);
+    interstitial.setCriteoInterstitialAdListener(new TestAppInterstitialAdListener(TAG, prefix));
 
-    btnShow.setOnClickListener(v -> showInterstitial(interstitial));
-
-    Log.d(TAG, prefix + " - Interstitial Requested");
-    Criteo.getInstance().loadBid(adUnit, loadAd(interstitial, CriteoInterstitial::loadAd));
+    Log.d(TAG, prefix + "Interstitial Requested");
+    Criteo.getInstance().loadBid(adUnit, interstitial::loadAd);
   }
 
   private <T> BidResponseListener loadAd(@NonNull T adLoader, @NonNull BiConsumer<T, Bid> loadAdAction) {

--- a/app/src/main/java/com/criteo/testapp/StandaloneActivity.java
+++ b/app/src/main/java/com/criteo/testapp/StandaloneActivity.java
@@ -22,7 +22,6 @@ import static com.criteo.testapp.PubSdkDemoApplication.NATIVE;
 
 import android.os.Bundle;
 import android.util.Log;
-import android.widget.Button;
 import android.widget.FrameLayout;
 import androidx.appcompat.app.AppCompatActivity;
 import com.criteo.publisher.CriteoBannerView;
@@ -42,8 +41,6 @@ public class StandaloneActivity extends AppCompatActivity {
 
   private CriteoBannerView criteoBannerView;
   private CriteoNativeLoader nativeLoader;
-  private Button btnShowInterstitial;
-  private Button btnShowInterstitialIbv;
   private FrameLayout nativeAdContainer;
 
   @Override
@@ -52,8 +49,6 @@ public class StandaloneActivity extends AppCompatActivity {
     setContentView(R.layout.activity_stand_alone);
     MockedIntegrationRegistry.force(Integration.STANDALONE);
 
-    btnShowInterstitial = findViewById(R.id.buttonStandAloneInterstitial);
-    btnShowInterstitialIbv = findViewById(R.id.buttonStandAloneInterstitialIbv);
     criteoBannerView = findViewById(R.id.criteoBannerView);
     nativeAdContainer = findViewById(R.id.nativeAdContainer);
 
@@ -68,6 +63,8 @@ public class StandaloneActivity extends AppCompatActivity {
 
     findViewById(R.id.buttonStandAloneBanner).setOnClickListener(v -> loadBannerAd());
     findViewById(R.id.buttonStandAloneNative).setOnClickListener(v -> loadNative());
+    findViewById(R.id.buttonStandAloneInterstitial).setOnClickListener(v -> loadInterstitial(INTERSTITIAL));
+    findViewById(R.id.buttonStandAloneInterstitialIbv).setOnClickListener(v -> loadInterstitial(INTERSTITIAL_IBV_DEMO));
   }
 
   private void loadBannerAd() {
@@ -83,33 +80,15 @@ public class StandaloneActivity extends AppCompatActivity {
     }
   }
 
-  @Override
-  protected void onResume() {
-    super.onResume();
-    btnShowInterstitial.setEnabled(false);
-    btnShowInterstitialIbv.setEnabled(false);
-    loadInterstitial(INTERSTITIAL, btnShowInterstitial);
-    loadInterstitial(INTERSTITIAL_IBV_DEMO, btnShowInterstitialIbv);
-  }
-
-  private void showInterstitial(CriteoInterstitial interstitial) {
-    if (interstitial.isAdLoaded()) {
-      interstitial.show();
-    }
-  }
-
   private void loadNative() {
     nativeLoader.loadAd();
   }
 
-  private void loadInterstitial(InterstitialAdUnit adUnit, Button btnShow) {
+  private void loadInterstitial(InterstitialAdUnit adUnit) {
     String prefix = "Standalone " + adUnit.getAdUnitId();
 
     CriteoInterstitial criteoInterstitial = new CriteoInterstitial(adUnit);
-    criteoInterstitial.setCriteoInterstitialAdListener(
-        new TestAppInterstitialAdListener(TAG, prefix, btnShow));
-
-    btnShow.setOnClickListener(v -> showInterstitial(criteoInterstitial));
+    criteoInterstitial.setCriteoInterstitialAdListener(new TestAppInterstitialAdListener(TAG, prefix));
 
     Log.d(TAG, prefix + "Interstitial Requested");
     criteoInterstitial.loadAd();

--- a/app/src/main/java/com/criteo/testapp/listener/TestAppInterstitialAdListener.java
+++ b/app/src/main/java/com/criteo/testapp/listener/TestAppInterstitialAdListener.java
@@ -17,38 +17,27 @@
 package com.criteo.testapp.listener;
 
 import android.util.Log;
-import android.widget.Button;
 import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
 import com.criteo.publisher.CriteoErrorCode;
 import com.criteo.publisher.CriteoInterstitial;
 import com.criteo.publisher.CriteoInterstitialAdListener;
-import java.lang.ref.WeakReference;
 
 public class TestAppInterstitialAdListener implements CriteoInterstitialAdListener {
 
   private final String tag;
   private final String prefix;
-  private final WeakReference<Button> btnShowInterstitialWeakRef;
 
-  public TestAppInterstitialAdListener(
-      String tag, String prefix,
-      Button btnShowInterstitial
-  ) {
+  public TestAppInterstitialAdListener(String tag, String prefix) {
     this.tag = tag;
     this.prefix = prefix;
-    this.btnShowInterstitialWeakRef = new WeakReference<>(btnShowInterstitial);
   }
 
   @UiThread
   @Override
   public void onAdReceived(@NonNull CriteoInterstitial interstitial) {
-    Button btnShowInterstitial = btnShowInterstitialWeakRef.get();
-    if (btnShowInterstitial != null) {
-      btnShowInterstitial.setEnabled(true);
-    }
-
     Log.d(tag, prefix + "Interstitial ad called onAdReceived");
+    interstitial.show();
   }
 
   @Override

--- a/app/src/main/res/layout/activity_stand_alone.xml
+++ b/app/src/main/res/layout/activity_stand_alone.xml
@@ -28,7 +28,6 @@
           android:layout_height="match_parent"
           android:layout_weight="1"
           android:background="@android:color/holo_blue_dark"
-          android:enabled="false"
           android:text="@string/btn_interstitial" />
         <Button
           android:id="@+id/buttonStandAloneBanner"
@@ -49,7 +48,6 @@
           android:layout_marginStart="5dp"
           android:layout_marginLeft="5dp"
           android:background="@android:color/holo_blue_dark"
-          android:enabled="false"
           android:text="@string/btn_interstitial_ibv" />
         <Button
           android:id="@+id/buttonStandAloneNative"


### PR DESCRIPTION
For Standalone and InHouse, before there was a distinction between:
- valid bid is received
- ad payload is received

To show this distinction, the bid was requested when the activity was
resumed. If valid bid is received, then a button is enabled. Testers had
to click on the button to display the Ad.

This distinction is removed: listener is notified when valid bid is
received AND ad payload is received. The testing process is
simplified to:
- Button is always enabled
- (Manual) Tester clicks on the button
- Bid is requested
- If bid is valid, then ad payload is requested
- If ad payload is received, then interstitial is shown
- (Manual) Tester checks quality of the Ad