### PR TITLE
Make connectedCheck work again

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,6 +36,10 @@ android {
         }
     }
 
+    packagingOptions {
+        exclude("META-INF/mediation_release.kotlin_module")
+    }
+
     defaultConfig {
         multiDexEnabled = true
     }


### PR DESCRIPTION
When running `./gradlew connectedCheck`, the following error was
triggered:

More than one file was found with OS independent path 'META-INF/mediation_release.kotlin_module'

Excluding this file is safe.