### PR TITLE
Bump ubuntu where CI executed on to 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   java-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -152,7 +152,7 @@ jobs:
             **/test-results/gordon/*.xml
 
   quality-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     needs:
       - java-tests


### PR DESCRIPTION
We're using `ubuntu-latest` as GitHub CI executor. This will change soon
from Ubuntu 18.04 to 20.04 which change default Java from Java 8 to Java
11.
This commit checks if we can keep `ubuntu-latest` or if we should use
`ubuntu-18.04`.

For more details, see
https://github.com/actions/virtual-environments/issues/1816