### PR TITLE
Disable analytics sent to Google when running tests

### DIFF
--- a/buildSrc/src/main/java/AndroidModule.kt
+++ b/buildSrc/src/main/java/AndroidModule.kt
@@ -95,6 +95,7 @@ private fun Project.defaultAndroidModule() {
       versionCode = 1
       versionName = sdkVersion()
       testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+      testInstrumentationRunnerArgument("disableAnalytics", "true")
     }
 
     fun BuildType.addProguardIfExists() {


### PR DESCRIPTION
The Android JUnit runner is sniffing some data when we run our tests.
The worse part is that sometimes the network connection is bad (I can't
tell if it was an issue client side or server side) and, after tests are
really finished, the tests process takes many seconds to stop.