### PR TITLE
Fix functional test on AppEvent

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/CriteoFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/CriteoFunctionalTest.java
@@ -26,6 +26,7 @@ import static org.mockito.AdditionalAnswers.answerVoid;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -35,7 +36,6 @@ import static org.mockito.Mockito.when;
 import android.app.Application;
 import android.content.Intent;
 import android.os.Looper;
-import androidx.test.filters.FlakyTest;
 import androidx.test.rule.ActivityTestRule;
 import com.criteo.publisher.BidManager;
 import com.criteo.publisher.Criteo;
@@ -167,7 +167,6 @@ public class CriteoFunctionalTest {
   }
 
   @Test
-  @FlakyTest
   public void init_GivenPrefetchAdUnitAndLaunchedActivity_CallConfigAndCdbAndBearcat()
       throws Exception {
     givenInitializedCriteo(validBannerAdUnit);
@@ -178,7 +177,8 @@ public class CriteoFunctionalTest {
 
     verify(api).loadCdb(any(), any());
     verify(api).loadConfig(any());
-    verify(api).postAppEvent(anyInt(), any(), any(), any(), anyInt(), any(), any());
+    verify(api).postAppEvent(anyInt(), any(), any(), eq("Launch"), anyInt(), any(), any());
+    verify(api).postAppEvent(anyInt(), any(), any(), eq("Active"), anyInt(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
This test is broken because of 2aa15017: AsyncTack of AppEvent is
replaced by Executor+Runnable. With AsyncTask, only a single GUM request
can be executed at the same time. With Executor, many GUM requests can
be done in parallel.

With new solution, it appears that two events are sent when starting a
new activity: Launch then Active events.

The former approach is tedious and not deterministic because if network
is slow, then only the "Launch" event is sent, if network is fast, then
both events are sent.

So test is updated to accept the two events. The @FlakyTest is also
removed on this test:
- the new solution is deterministic
- recent work was done to isolate tests, particularly on AppEvents