### PR TITLE
Tag change (CriteoSdk) + GUM gdpr param key (#169)

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/ConsoleHandler.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/ConsoleHandler.kt
@@ -25,7 +25,6 @@ import com.criteo.publisher.util.BuildConfigWrapper
 internal class ConsoleHandler(private val buildConfigWrapper: BuildConfigWrapper) : LogHandler {
 
   companion object {
-    const val TagPrefix = "Crto"
     private const val UnsetLogLevel = -1
   }
 
@@ -50,7 +49,7 @@ internal class ConsoleHandler(private val buildConfigWrapper: BuildConfigWrapper
 
   @VisibleForTesting
   fun println(level: Int, tag: String, message: String) {
-    Log.println(level, "$TagPrefix$tag", message)
+    Log.println(level, LogTag.with(tag), message)
   }
 
   private val Throwable.stacktraceString get() = getStackTraceString(this)

--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/LogTag.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/LogTag.kt
@@ -1,0 +1,32 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher.logging
+
+internal object LogTag {
+  private const val TagPrefix = "CriteoSdk"
+
+  /**
+   * IllegalArgumentException is thrown if the tag.length() > 23 for Nougat (7.0)
+   * releases (API <= 23) and prior, there is no tag limit of concern after this API level.
+   *
+   * @see [documentation](https://developer.android.com/reference/android/util/Log.html)
+   */
+  private const val TagMaxLength = 23
+
+  @JvmStatic
+  fun with(str: String) = "$TagPrefix$str".take(TagMaxLength)
+}

--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/Logger.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/Logger.java
@@ -16,8 +16,6 @@
 
 package com.criteo.publisher.logging;
 
-import static com.criteo.publisher.logging.ConsoleHandler.TagPrefix;
-
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
@@ -25,7 +23,7 @@ import java.util.List;
 
 public class Logger {
 
-  private static final String FALLBACK_TAG = TagPrefix + "Logger";
+  private static final String FALLBACK_TAG = LogTag.with("Logger");
 
   @NonNull
   private final String tag;

--- a/publisher-sdk/src/main/java/com/criteo/publisher/network/PubSdkApi.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/network/PubSdkApi.java
@@ -48,7 +48,7 @@ public class PubSdkApi {
   private static final String GAID = "gaid";
   private static final String EVENT_TYPE = "eventType";
   private static final String LIMITED_AD_TRACKING = "limitedAdTracking";
-  private static final String GDPR_STRING = "gdprString";
+  private static final String GDPR_CONSENT = "gdpr_consent";
 
   @NonNull
   private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -118,7 +118,7 @@ public class PubSdkApi {
     parameters.put(LIMITED_AD_TRACKING, String.valueOf(limitedAdTracking));
 
     if (gdprConsentData != null) {
-        parameters.put(GDPR_STRING, gdprConsentData);
+        parameters.put(GDPR_CONSENT, gdprConsentData);
     }
 
     String query = "/appevent/v1/" + senderId + "?" + getParamsString(parameters);

--- a/publisher-sdk/src/test/java/com/criteo/publisher/logging/LogTagTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/logging/LogTagTest.kt
@@ -1,0 +1,30 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher.logging
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class LogTagTest {
+  @Test
+  fun with_ExceedingLimit() {
+    val truncated = LogTag.with("FourtheenChars+1")
+    val expected = "CriteoSdkFourtheenChars"
+    assertThat(expected.length).isEqualTo(23)
+    assertThat(truncated).isEqualTo(expected)
+  }
+}

--- a/publisher-sdk/src/test/java/com/criteo/publisher/network/PubSdkApiTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/network/PubSdkApiTest.java
@@ -160,7 +160,7 @@ public class PubSdkApiTest {
     assertThat(request.getRequestUrl().queryParameter("gaid")).isEqualTo("myGaid");
     assertThat(request.getRequestUrl().queryParameter("eventType")).isEqualTo("myEvent");
     assertThat(request.getRequestUrl().queryParameter("limitedAdTracking")).isEqualTo("1337");
-    assertThat(request.getRequestUrl().queryParameter("gdprString")).isEqualTo("fake_consent_data");
+    assertThat(request.getRequestUrl().queryParameter("gdpr_consent")).isEqualTo("fake_consent_data");
   }
 
   @Test
@@ -180,7 +180,7 @@ public class PubSdkApiTest {
     api.postAppEvent(42, "", "myGaid", "", 0, "", null);
 
     RecordedRequest request = mockWebServer.takeRequest();
-    assertThat(request.getRequestUrl().queryParameter("gdprString")).isNull();
+    assertThat(request.getRequestUrl().queryParameter("gdpr_consent")).isNull();
   }
 
   @Test


### PR DESCRIPTION
* Use gdpr_consent instead of gdprString for GUM

Although this is not consistent with all the other keys,
PTag already uses this key and the idea was to align with
IAB standard.

* Use CriteoSdk instead of Crto as log tags