### PR TITLE
Fix the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.7
+        uses: malinskiy/action-android/install-sdk@release/0.0.8
 
       - name: Deploy artifacts and notify on Slack
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 3.10.2
+-Bug fix
+ - Ensure `CriteoInterstitialActivity` does not crash when it is open by system and SDK is not
+  initialized yet.
+
 # Version 3.10.1
 - Bug fix
  - Ensure `CriteoInterstitialActivity` does not crash when the `application` object is null.

--- a/buildSrc/src/main/java/SdkVersion.kt
+++ b/buildSrc/src/main/java/SdkVersion.kt
@@ -18,7 +18,7 @@ import org.gradle.api.Project
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-private const val sdkBaseVersion = "3.10.1"
+private const val sdkBaseVersion = "3.10.2"
 
 private val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd.HHmm"))
 


### PR DESCRIPTION
action-android is updated as the previous version uses deprecated
commands.

While 3.10.2 is no longer under development, this change is necessary as
this version is needed by a specific publisher.
