### PR TITLE
Fix the release workflow for v3.10.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.7
+        uses: malinskiy/action-android/install-sdk@release/0.0.8
 
       - name: Deploy artifacts and notify on Slack
         env:


### PR DESCRIPTION
action-android is updated as the previous version uses deprecated
commands.

While 3.10.2 is no longer under development, this change is necessary as
this version is needed by a specific publisher.