### PR TITLE
Bump version of malinskiy's GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
 
       - name: Set up Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.7
+        uses: malinskiy/action-android/install-sdk@release/0.0.8
 
       # This cache below is not fully working: it should go above the "Set up Android SDK" but:
       # - The action does not support having a SDK already setup -> platform-tools, licenses are re-downloaded
@@ -72,12 +72,12 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
 
       - name: Set up Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.7
+        uses: malinskiy/action-android/install-sdk@release/0.0.8
 
       # On merge, run non-flaky-tests without retry then flaky tests with retry policy
       - name: Run all Android tests
-        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
-        if: github.event_name != 'pull_request'
+        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.8
+        if: github.event_name == 'push'
         with:
           api: 29
           tag: google_apis
@@ -93,8 +93,8 @@ jobs:
 
       # Run only non-flaky tests on PR
       - name: Run Android tests w/o @FlakyTest
-        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.7
-        if: github.event_name == 'pull_request'
+        uses: malinskiy/action-android/emulator-run-cmd@release/0.0.8
+        if: github.event_name != 'push'
         with:
           api: 29
           tag: google_apis
@@ -184,7 +184,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.7
+        uses: malinskiy/action-android/install-sdk@release/0.0.8
 
       - name: Deploy artifacts and notify on Slack
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Android SDK
-        uses: malinskiy/action-android/install-sdk@release/0.0.7
+        uses: malinskiy/action-android/install-sdk@release/0.0.8
 
       - name: Deploy artifacts and notify on Slack
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,8 @@ sonarqube {
     val junitReportFiles = allSubProjectsReports("**/TEST-*.xml") + // Normal tests
         allSubProjectsReports("test-results/gordon/*.xml") // Retried tests (Gordon runner)
     val junitReportDirs = junitReportFiles.mapNotNull { it.parentFile }.toSet()
-    property("sonar.junit.reportPaths", junitReportDirs)
+    // FIXME EE-1335 Reactivate and fix declaration of JUnit reports to Sonar
+    // property("sonar.junit.reportPaths", junitReportDirs)
 
     val lintReports = allSubProjectsReports("reports/lint-results.xml")
     property("sonar.androidLint.reportPaths", lintReports)


### PR DESCRIPTION
This new version solves the deprecated `set-env`.

JIRA: EE-1365