### PR TITLE
Make AdvertisingInfo callable on any thread

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/advancednative/AdvancedNativeFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/advancednative/AdvancedNativeFunctionalTest.java
@@ -41,6 +41,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import android.content.Intent;
@@ -130,9 +131,13 @@ public class AdvancedNativeFunctionalTest {
     Criteo.getInstance().loadBid(NATIVE, new ContextData(), activity::loadInHouseAdInAdLayout);
     mockedDependenciesRule.waitForIdleState();
 
-    // Check there is one ad
+    // Load a second ad because detection of InHouse profileId is delayed of one bid
+    Criteo.getInstance().loadBid(NATIVE, new ContextData(), activity::loadInHouseAdInAdLayout);
+    mockedDependenciesRule.waitForIdleState();
+
+    // Check there is two ads
     ViewGroup adLayout = getAdLayout();
-    assertEquals(1, adLayout.getChildCount());
+    assertEquals(2, adLayout.getChildCount());
 
     checkAllInformationAreDisplayed((ViewGroup) adLayout.getChildAt(0));
 
@@ -141,7 +146,7 @@ public class AdvancedNativeFunctionalTest {
         any()
     );
 
-    verify(logger).log(onNativeImpressionRegistered((NativeAdUnit) null));
+    verify(logger, times(2)).log(onNativeImpressionRegistered((NativeAdUnit) null));
     verify(logger, atLeastOnce()).log(onNativeClicked((NativeAdUnit) null));
   }
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CriteoInternal.java
@@ -78,6 +78,8 @@ class CriteoInternal extends Criteo {
     deviceInfo = dependencyProvider.provideDeviceInfo();
     deviceInfo.initialize();
 
+    dependencyProvider.provideAdvertisingInfo().prefetch();
+
     config = dependencyProvider.provideConfig();
 
     bidManager = dependencyProvider.provideBidManager();

--- a/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
@@ -199,7 +199,8 @@ public class DependencyProvider {
   @NonNull
   public AdvertisingInfo provideAdvertisingInfo() {
     return getOrCreate(AdvertisingInfo.class, () -> new AdvertisingInfo(
-        provideContext()
+        provideContext(),
+        provideThreadPoolExecutor()
     ));
   }
 

--- a/publisher-sdk/src/main/java/com/criteo/publisher/util/AdvertisingInfo.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/util/AdvertisingInfo.java
@@ -17,55 +17,129 @@
 package com.criteo.publisher.util;
 
 import android.content.Context;
+import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.annotation.WorkerThread;
+import com.criteo.publisher.SafeRunnable;
 import com.criteo.publisher.logging.Logger;
 import com.criteo.publisher.logging.LoggerFactory;
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
 import com.google.android.gms.ads.identifier.AdvertisingIdClient.Info;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class AdvertisingInfo {
-
-  private static final String DEVICE_ID_LIMITED = "00000000-0000-0000-0000-000000000000";
 
   @NonNull
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   @NonNull
-  private final SafeAdvertisingIdClient advertisingIdClient = new SafeAdvertisingIdClient();
+  private final SafeAdvertisingIdClient advertisingIdClient;
 
   @NonNull
   private final Context context;
 
-  public AdvertisingInfo(@NonNull Context context) {
+  @NonNull
+  private final Executor executor;
+
+  @NonNull
+  private final AtomicReference<AdvertisingIdResult> resultRef = new AtomicReference<>();
+
+  public AdvertisingInfo(
+      @NonNull Context context,
+      @NonNull Executor executor
+  ) {
+    this(context, executor, new SafeAdvertisingIdClient());
+  }
+
+  @VisibleForTesting
+  AdvertisingInfo(
+      @NonNull Context context,
+      @NonNull Executor executor,
+      @NonNull SafeAdvertisingIdClient advertisingIdClient
+  ) {
     this.context = context;
+    this.executor = executor;
+    this.advertisingIdClient = advertisingIdClient;
+  }
+
+  public void prefetch() {
+    getAdvertisingIdResult();
   }
 
   @Nullable
   public String getAdvertisingId() {
-    if (isLimitAdTrackingEnabled()) {
-      return DEVICE_ID_LIMITED;
-    }
-
-    try {
-      return advertisingIdClient.getId(context);
-    } catch (Exception e) {
-      logger.debug("Error getting advertising id", e);
-      return null;
-    }
+    return getAdvertisingIdResult().getId();
   }
 
   public boolean isLimitAdTrackingEnabled() {
-    try {
-      return advertisingIdClient.isLimitAdTrackingEnabled(context);
-    } catch (Exception e) {
-      logger.debug("Error checking if ad tracking is limited", e);
-      return false;
+    return getAdvertisingIdResult().isLimitAdTrackingEnabled();
+  }
+
+  private AdvertisingIdResult getAdvertisingIdResult() {
+    AdvertisingIdResult advertisingIdResult = resultRef.get();
+    if (advertisingIdResult == null) {
+      // Multiple concurrent tasks are accepted. Only one commit is accepted then.
+      if (isMainThread()) {
+        executor.execute(new SafeRunnable() {
+          @Override
+          public void runSafely() {
+            fetchResultOnWorkerThread();
+          }
+        });
+      } else {
+        fetchResultOnWorkerThread();
+      }
+    }
+
+    advertisingIdResult = resultRef.get();
+    if (advertisingIdResult == null) {
+      return AdvertisingIdResult.defaultAdvertisingIdResult();
+    } else {
+      return advertisingIdResult;
     }
   }
 
-  private static class SafeAdvertisingIdClient {
+  private boolean isMainThread() {
+    Looper mainLooper = Looper.getMainLooper();
+    if (mainLooper == null) {
+      return false;
+    }
+    return Thread.currentThread().equals(mainLooper.getThread());
+  }
 
+  @WorkerThread
+  private void fetchResultOnWorkerThread() {
+    AdvertisingIdResult advertisingIdResult;
+
+    try {
+      String id = advertisingIdClient.getId(context);
+      boolean limitAdTrackingEnabled = advertisingIdClient.isLimitAdTrackingEnabled(context);
+
+      if (limitAdTrackingEnabled) {
+        advertisingIdResult = AdvertisingIdResult.limitedAdvertisingIdResult();
+      } else {
+        advertisingIdResult = AdvertisingIdResult.unlimitedAdvertisingIdResult(id);
+      }
+    } catch (MissingPlayServicesAdsIdentifierException e) {
+      // This cannot be fixed during the runtime. Let's cache the failure.
+      advertisingIdResult = AdvertisingIdResult.defaultAdvertisingIdResult();
+      logger.debug("Error getting advertising id", e);
+    } catch (Exception e) {
+      // Keep trying to get result on next try
+      logger.debug("Error getting advertising id", e);
+      return;
+    }
+
+    resultRef.compareAndSet(null, advertisingIdResult);
+  }
+
+  @VisibleForTesting
+  static class SafeAdvertisingIdClient {
+
+    @WorkerThread // Google API throws when getting the advertising ID on main thread because of potential deadlock.
     public String getId(@NonNull Context context) throws Exception {
       try {
         Info advertisingIdInfo = AdvertisingIdClient.getAdvertisingIdInfo(context);
@@ -75,6 +149,7 @@ public class AdvertisingInfo {
       }
     }
 
+    @WorkerThread // Google API throws when getting the advertising ID on main thread because of potential deadlock.
     public boolean isLimitAdTrackingEnabled(@NonNull Context context) throws Exception {
       try {
         Info advertisingIdInfo = AdvertisingIdClient.getAdvertisingIdInfo(context);
@@ -83,7 +158,49 @@ public class AdvertisingInfo {
         throw new MissingPlayServicesAdsIdentifierException(e);
       }
     }
+  }
 
+  private static class AdvertisingIdResult {
+
+    private static final AdvertisingIdResult DEFAULT_INSTANCE = new AdvertisingIdResult(null, false);
+    private static final AdvertisingIdResult LIMITED_INSTANCE = new AdvertisingIdResult(
+        "00000000-0000-0000-0000-000000000000",
+        true
+    );
+
+    @Nullable
+    private final String id;
+
+    private final boolean isLimitAdTrackingEnabled;
+
+    private AdvertisingIdResult(
+        @Nullable String id,
+        boolean isLimitAdTrackingEnabled
+    ) {
+      this.id = id;
+      this.isLimitAdTrackingEnabled = isLimitAdTrackingEnabled;
+    }
+
+    static AdvertisingIdResult unlimitedAdvertisingIdResult(@NonNull String id) {
+      return new AdvertisingIdResult(id, false);
+    }
+
+    static AdvertisingIdResult limitedAdvertisingIdResult() {
+      return LIMITED_INSTANCE;
+    }
+
+    static AdvertisingIdResult defaultAdvertisingIdResult() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @Nullable
+    public String getId() {
+      return id;
+    }
+
+    public boolean isLimitAdTrackingEnabled() {
+      return isLimitAdTrackingEnabled;
+    }
   }
 
   static class MissingPlayServicesAdsIdentifierException extends Exception {

--- a/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInternalUnitTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/CriteoInternalUnitTest.java
@@ -39,9 +39,9 @@ import com.criteo.publisher.model.AdUnit;
 import com.criteo.publisher.model.Config;
 import com.criteo.publisher.model.DeviceInfo;
 import com.criteo.publisher.privacy.UserPrivacyUtil;
+import com.criteo.publisher.util.AdvertisingInfo;
 import com.criteo.publisher.util.AppLifecycleUtil;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -194,6 +194,16 @@ public class CriteoInternalUnitTest {
     createCriteo();
 
     verify(deviceInfo).initialize();
+  }
+
+  @Test
+  public void whenCreatingNewCriteo_GivenAdvertisingInfo_PrefetchIt() throws Exception {
+    AdvertisingInfo advertisingInfo = mock(AdvertisingInfo.class);
+    doReturn(advertisingInfo).when(dependencyProvider).provideAdvertisingInfo();
+
+    createCriteo();
+
+    verify(advertisingInfo).prefetch();
   }
 
   @Test

--- a/publisher-sdk/src/test/java/com/criteo/publisher/util/AdvertisingInfoNoIdentifierTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/util/AdvertisingInfoNoIdentifierTest.kt
@@ -20,7 +20,6 @@ import com.criteo.publisher.mock.MockedDependenciesRule
 import com.criteo.publisher.mock.SpyBean
 import com.criteo.publisher.util.AdvertisingInfo.MissingPlayServicesAdsIdentifierException
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -63,7 +62,7 @@ via IntelliJ delegating test run to Gradle.
     val advertisingId = advertisingInfo.advertisingId
 
     assertThat(advertisingId).isNull()
-    verify(logger, times(2)).debug(any(), any<MissingPlayServicesAdsIdentifierException>())
+    verify(logger).debug(any(), any<MissingPlayServicesAdsIdentifierException>())
   }
 
   @Test


### PR DESCRIPTION
The Google API is throwing an exception when called on the main thread:
```
java.lang.IllegalStateException: Calling this from your main thread can lead to deadlock
```

The GAID is fetched in 4 cases:
- when creating the CDB request
- when creating the Bearcat request
- when creating the remote config request
- when creating the remote logs request

The 3 first cases are done on worker thread and current solution is ok.
The remote log case can be done on any thread, including the main one
which is problematic.

To solve this issue we can either:
1. run remote log handler/logger in a (dedicated?) worker thread
2. refactor AdvertisingInfo class to have an async API (listener/future)
3. make AdvertisingInfo callable from any thread

# Proposition 1
Pros:
- slow logger cannot impact business
- no change needed on AdvertisingInfo class
Cons:
- threadId field in logcat or remote log became useless
- impossible or really hard to detect recursive logs and repercussion is
disastrous: instead of 1 stack overflow on 1 thread, the SDK can be a
fork bomb taking 100% of CPU and/or RAM

# Proposition 2
Pros:
- make no assumption
Cons:
- huge refactoring needed
- async API are contaminant: all call stack should be refactored

# Proposition 3
Pros:
- only local change required in AdvertisingInfo class
- no change for caller
Cons:
- assume that GAID is constant
- GAID is available for main thread only after a first call

This commit is implementing the proposition 3.

About the assumption that GAID is constant: to limit the GAID, user
should go deeply in device parameter. When user come back to the
application, either the Android killed the app and the SDK is reinit
again, either the app is still alive, then assumption is false.

About the fact that GAID is available for main thread only after a first
call, this is fixed by prefetching it during SDK init.