### PR TITLE
Fix flaky MoPub tests

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/MoPubHeaderBiddingFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/integration/MoPubHeaderBiddingFunctionalTest.java
@@ -355,11 +355,8 @@ public class MoPubHeaderBiddingFunctionalTest {
   }
 
   private void assertBidRequestHasGoodProfileId() throws Exception {
-    if (config.isLiveBiddingEnabled()) {
-      // With live bidding, AppBidding declaration is delayed when bid is consumed. So the declaration is only visible
-      // from the next bid.
-      loadAdAndWait(invalidBannerAdUnit, null);
-    }
+    // AppBidding declaration is delayed when bid is consumed. So the declaration is only visible from the next bid.
+    loadAdAndWait(invalidBannerAdUnit, null);
 
     verify(api, atLeastOnce()).loadCdb(
         argThat(request -> request.getProfileId() == Integration.MOPUB_APP_BIDDING.getProfileId()),


### PR DESCRIPTION
AppBidding declaration is delayed when bid is consumed. For live
bidding, it is 100% sure that good profile ID is only visible on next
bid request.
For cache bidding, then it depends on the threads scheduling. Such tests
are now flaky, this means that a previous commit did change the
scheduling.

The commit 94ddc4d7 is a good candidate as it is recent and change main
thread usage. For cache bidding, we have:
- valid bid is retrieved from cache (test thread)
- bid is consumed (main thread)
- MoPub profile ID is declared (main thread) (1)
- bid is fetched for cache (worker thread)
- GAID is fetched for bid request (worker thread) (2)
- Profile ID is fetched for bid request (worker thread) (3)
- ...

(1) and (3) are concurrent events, and without synchronization, there is
no deterministic ordering. Previously for (2), the GAID was always fetch
with the Google API, which seemed to need th main thread. This can be
the synchronization that keep those test deterministic. Now for (2), the
GAID is cached at SDK init, so there is no sync.

A second call is then necessary to ensure the deterministic outcome.