### PR TITLE
Show millis of client date time when generating remote logs

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogRecordsFactory.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogRecordsFactory.kt
@@ -43,7 +43,7 @@ internal class RemoteLogRecordsFactory(
     private val clock: Clock
 ) {
 
-  private val iso8601Format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT).apply {
+  private val iso8601Format = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ROOT).apply {
     timeZone = TimeZone.getTimeZone("UTC")
   }
 

--- a/publisher-sdk/src/test/java/com/criteo/publisher/logging/RemoteLogRecordsFactoryTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/logging/RemoteLogRecordsFactoryTest.kt
@@ -84,7 +84,7 @@ class RemoteLogRecordsFactoryTest {
 
   @Test
   fun createLogRecord_GivenValidLog_ReturnLogRecords() {
-    val timestamp = ZonedDateTime.of(2042, 6, 22, 13, 37, 28, 2, ZoneOffset.UTC).toInstant().toEpochMilli()
+    val timestamp = ZonedDateTime.of(2042, 6, 22, 13, 37, 28, 123_000_000, ZoneOffset.UTC).toInstant().toEpochMilli()
 
     whenever(buildConfigWrapper.sdkVersion).doReturn("1.2.3")
     whenever(context.packageName).doReturn("org.dummy")
@@ -101,7 +101,11 @@ class RemoteLogRecordsFactoryTest {
 
     val logRecords = factory.createLogRecords(logMessage)
 
-    val expectedMessage = "`message of log`,`throwable message+stacktrace`,threadId:thread-name,2042-06-22T13:37:28Z"
+    val expectedMessage = "`message of log`," +
+        "`throwable message+stacktrace`," +
+        "threadId:thread-name," +
+        "2042-06-22T13:37:28.123Z"
+
     assertThat(logRecords).isEqualTo(RemoteLogRecords(
         RemoteLogContext(
             "1.2.3",
@@ -126,7 +130,7 @@ class RemoteLogRecordsFactoryTest {
 
   @Test
   fun createMessageBody_GivenOnlyMessage_FormatItWithoutStacktrace() {
-    val timestamp = ZonedDateTime.of(2042, 6, 22, 13, 37, 28, 2, ZoneOffset.UTC).toInstant().toEpochMilli()
+    val timestamp = ZonedDateTime.of(2042, 6, 22, 13, 37, 28, 123_000, ZoneOffset.UTC).toInstant().toEpochMilli()
     whenever(clock.currentTimeInMillis).doReturn(timestamp)
     doReturn("thread-name").whenever(factory).getCurrentThreadName()
 
@@ -134,13 +138,13 @@ class RemoteLogRecordsFactoryTest {
 
     val messageBody = factory.createMessageBody(logMessage)
 
-    assertThat(messageBody).isEqualTo("dummy message,threadId:thread-name,2042-06-22T13:37:28Z")
+    assertThat(messageBody).isEqualTo("dummy message,threadId:thread-name,2042-06-22T13:37:28.000Z")
   }
 
   @Test
   fun createMessageBody_GivenOnlyThrowable_FormatItWithStacktrace() {
     val throwable = NullPointerException()
-    val timestamp = ZonedDateTime.of(2042, 6, 22, 13, 37, 28, 2, ZoneOffset.UTC).toInstant().toEpochMilli()
+    val timestamp = ZonedDateTime.of(2042, 6, 22, 13, 37, 28, 12_300_000, ZoneOffset.UTC).toInstant().toEpochMilli()
     whenever(clock.currentTimeInMillis).doReturn(timestamp)
     doReturn("thread-name").whenever(factory).getCurrentThreadName()
     doReturn("throwable message+stacktrace").whenever(factory).getStackTraceString(throwable)
@@ -149,6 +153,6 @@ class RemoteLogRecordsFactoryTest {
 
     val messageBody = factory.createMessageBody(logMessage)
 
-    assertThat(messageBody).isEqualTo("throwable message+stacktrace,threadId:thread-name,2042-06-22T13:37:28Z")
+    assertThat(messageBody).isEqualTo("throwable message+stacktrace,threadId:thread-name,2042-06-22T13:37:28.012Z")
   }
 }


### PR DESCRIPTION
Remote logs are bulk. So each chunk has the same server time. To be able
to reorder the logs, the client date time is included in the message.
Before, time was printed only down to seconds which is a too big unit of
time. So it was almost impossible to use it.
This commit shows the milliseconds too, so one can distinguish the real
log order.

Maybe for later:
Even with millis, logs might not be fully reorder. An atomic log IDs
could be used instead.