### PR TITLE
Send CSM data only if consent is given

### DIFF
--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/BidManagerFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/BidManagerFunctionalTest.java
@@ -1749,7 +1749,8 @@ public class BidManagerFunctionalTest {
         dependencyProvider.provideLiveBidRequestSender(),
         dependencyProvider.provideBidLifecycleListener(),
         dependencyProvider.provideMetricSendingQueueConsumer(),
-        remoteLogSendingQueueConsumer
+        remoteLogSendingQueueConsumer,
+        dependencyProvider.provideConsentData()
     );
   }
 

--- a/publisher-sdk/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
+++ b/publisher-sdk/src/androidTest/java/com/criteo/publisher/csm/CsmFunctionalTest.java
@@ -37,6 +37,7 @@ import androidx.core.util.Consumer;
 import androidx.test.filters.FlakyTest;
 import com.criteo.publisher.Clock;
 import com.criteo.publisher.Criteo;
+import com.criteo.publisher.CriteoInitException;
 import com.criteo.publisher.TestAdUnits;
 import com.criteo.publisher.context.ContextData;
 import com.criteo.publisher.csm.MetricRequest.MetricRequestFeedback;
@@ -86,6 +87,7 @@ public class CsmFunctionalTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     integrationRegistry.declare(Integration.IN_HOUSE);
+    givenConsentGiven();
   }
 
   @Test
@@ -137,6 +139,16 @@ public class CsmFunctionalTest {
 
       return true;
     }));
+  }
+
+  /**
+   * Consent status is updated after the first response from CDB. Therefore, a first bid-request
+   * is made here to get the wanted side-effect.
+   */
+  private void givenConsentGiven() throws CriteoInitException {
+    givenInitializedCriteo(TestAdUnits.BANNER_320_480);
+    waitForIdleState();
+    MetricHelper.cleanState(mockedDependenciesRule.getDependencyProvider());
   }
 
   @Test

--- a/publisher-sdk/src/main/java/com/criteo/publisher/CdbCallListener.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/CdbCallListener.kt
@@ -22,12 +22,16 @@ import com.criteo.publisher.annotation.OpenForTesting
 import com.criteo.publisher.bid.BidLifecycleListener
 import com.criteo.publisher.model.CdbRequest
 import com.criteo.publisher.model.CdbResponse
+import com.criteo.publisher.privacy.ConsentData
+import com.criteo.publisher.privacy.ConsentData.ConsentStatus.CONSENT_GIVEN
+import com.criteo.publisher.privacy.ConsentData.ConsentStatus.CONSENT_NOT_GIVEN
 
 @Internal
 @OpenForTesting
 abstract class CdbCallListener(
     private val bidLifecycleListener: BidLifecycleListener,
-    private val bidManager: BidManager
+    private val bidManager: BidManager,
+    private val consentData: ConsentData
 ) {
   @CallSuper
   fun onCdbRequest(cdbRequest: CdbRequest) {
@@ -41,6 +45,12 @@ abstract class CdbCallListener(
 
   @CallSuper
   fun onCdbResponse(cdbRequest: CdbRequest, cdbResponse: CdbResponse) {
+    if (cdbResponse.consentGiven) {
+      consentData.consentStatus = CONSENT_GIVEN
+    } else {
+      consentData.consentStatus = CONSENT_NOT_GIVEN
+    }
+
     bidManager.setTimeToNextCall(cdbResponse.timeToNextCall)
     bidLifecycleListener.onCdbCallFinished(cdbRequest, cdbResponse)
   }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
@@ -89,6 +89,7 @@ import com.criteo.publisher.model.RemoteConfigRequestFactory;
 import com.criteo.publisher.network.BidRequestSender;
 import com.criteo.publisher.network.LiveBidRequestSender;
 import com.criteo.publisher.network.PubSdkApi;
+import com.criteo.publisher.privacy.ConsentData;
 import com.criteo.publisher.privacy.UserPrivacyUtil;
 import com.criteo.publisher.util.AdvertisingInfo;
 import com.criteo.publisher.util.AndroidUtil;
@@ -267,7 +268,8 @@ public class DependencyProvider {
         provideLiveBidRequestSender(),
         provideBidLifecycleListener(),
         provideMetricSendingQueueConsumer(),
-        provideRemoteLogSendingQueueConsumer()
+        provideRemoteLogSendingQueueConsumer(),
+        provideConsentData()
     ));
   }
 
@@ -378,9 +380,10 @@ public class DependencyProvider {
       if (android.os.Build.VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
         listener.add(new CsmBidLifecycleListener(
             provideMetricRepository(),
-            new MetricSendingQueueProducer(provideMetricSendingQueue()),
+            provideMetricSendingQueueProducer(),
             provideClock(),
             provideConfig(),
+            provideConsentData(),
             provideThreadPoolExecutor()
         ));
       }
@@ -544,6 +547,14 @@ public class DependencyProvider {
   }
 
   @NonNull
+  public MetricSendingQueueProducer provideMetricSendingQueueProducer() {
+    return getOrCreate(MetricSendingQueueProducer.class, () -> new MetricSendingQueueProducer(
+        provideMetricSendingQueue()
+    ));
+  }
+
+
+  @NonNull
   public MetricSendingQueue provideMetricSendingQueue() {
     return getOrCreate(MetricSendingQueue.class, () -> new AdapterMetricSendingQueue(
         provideSendingQueue(provideMetricSendingQueueConfiguration())
@@ -694,6 +705,11 @@ public class DependencyProvider {
         provideBuildConfigWrapper(),
         provideThreadPoolExecutor()
     ));
+  }
+
+  @NonNull
+  public ConsentData provideConsentData() {
+    return getOrCreate(ConsentData.class, ConsentData::new);
   }
 
   public interface Factory<T> {

--- a/publisher-sdk/src/main/java/com/criteo/publisher/LiveCdbCallListener.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/LiveCdbCallListener.java
@@ -26,6 +26,7 @@ import com.criteo.publisher.model.CacheAdUnit;
 import com.criteo.publisher.model.CdbRequest;
 import com.criteo.publisher.model.CdbResponse;
 import com.criteo.publisher.model.CdbResponseSlot;
+import com.criteo.publisher.privacy.ConsentData;
 import com.criteo.publisher.util.PreconditionsUtil;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -61,9 +62,10 @@ public class LiveCdbCallListener extends CdbCallListener {
       @NonNull BidListener bidListener,
       @NonNull BidLifecycleListener bidLifecycleListener,
       @NonNull BidManager bidManager,
-      @NonNull CacheAdUnit cacheAdUnit
+      @NonNull CacheAdUnit cacheAdUnit,
+      @NonNull ConsentData consentData
   ) {
-    super(bidLifecycleListener, bidManager);
+    super(bidLifecycleListener, bidManager, consentData);
     this.bidListener = bidListener;
     this.bidLifecycleListener = bidLifecycleListener;
     this.bidManager = bidManager;

--- a/publisher-sdk/src/main/java/com/criteo/publisher/csm/CsmBidLifecycleListener.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/csm/CsmBidLifecycleListener.java
@@ -16,6 +16,8 @@
 
 package com.criteo.publisher.csm;
 
+import static com.criteo.publisher.privacy.ConsentData.ConsentStatus.CONSENT_NOT_GIVEN;
+
 import androidx.annotation.NonNull;
 import com.criteo.publisher.Clock;
 import com.criteo.publisher.SafeRunnable;
@@ -27,6 +29,8 @@ import com.criteo.publisher.model.CdbRequestSlot;
 import com.criteo.publisher.model.CdbResponse;
 import com.criteo.publisher.model.CdbResponseSlot;
 import com.criteo.publisher.model.Config;
+import com.criteo.publisher.privacy.ConsentData;
+
 import java.io.InterruptedIOException;
 import java.util.concurrent.Executor;
 
@@ -51,6 +55,9 @@ public class CsmBidLifecycleListener implements BidLifecycleListener {
   private final Config config;
 
   @NonNull
+  private final ConsentData consentData;
+
+  @NonNull
   private final Executor executor;
 
   public CsmBidLifecycleListener(
@@ -58,12 +65,14 @@ public class CsmBidLifecycleListener implements BidLifecycleListener {
       @NonNull MetricSendingQueueProducer sendingQueueProducer,
       @NonNull Clock clock,
       @NonNull Config config,
+      @NonNull ConsentData consentData,
       @NonNull Executor executor
   ) {
     this.repository = repository;
     this.sendingQueueProducer = sendingQueueProducer;
     this.clock = clock;
     this.config = config;
+    this.consentData = consentData;
     this.executor = executor;
   }
 
@@ -287,6 +296,6 @@ public class CsmBidLifecycleListener implements BidLifecycleListener {
   }
 
   private boolean isCsmDisabled() {
-    return !config.isCsmEnabled();
+    return !config.isCsmEnabled() || consentData.getConsentStatus() == CONSENT_NOT_GIVEN;
   }
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/csm/MetricSendingQueueProducer.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/csm/MetricSendingQueueProducer.java
@@ -17,6 +17,7 @@
 package com.criteo.publisher.csm;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 
 public class MetricSendingQueueProducer {
 
@@ -27,7 +28,8 @@ public class MetricSendingQueueProducer {
     this.queue = queue;
   }
 
-  void pushAllInQueue(@NonNull MetricRepository repository) {
+  @VisibleForTesting
+  public void pushAllInQueue(@NonNull MetricRepository repository) {
     for (Metric metric : repository.getAllStoredMetrics()) {
       pushInQueue(repository, metric.getImpressionId());
     }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/model/CdbResponse.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/model/CdbResponse.java
@@ -30,18 +30,23 @@ public class CdbResponse {
 
   private static final String TIME_TO_NEXT_CALL = "timeToNextCall";
   private static final String SLOTS = "slots";
+  private static final String CONSENT_GIVEN = "consentGiven";
 
   @NonNull
   private final List<CdbResponseSlot> slots;
 
   private final int timeToNextCall;
 
+  private final boolean consentGiven;
+
   public CdbResponse(
       @NonNull List<CdbResponseSlot> slots,
-      int timeToNextCall
-  ) {
+      int timeToNextCall,
+      @NonNull boolean consentGiven
+      ) {
     this.slots = slots;
     this.timeToNextCall = timeToNextCall;
+    this.consentGiven = consentGiven;
   }
 
   @NonNull
@@ -64,19 +69,28 @@ public class CdbResponse {
       try {
         array = json.getJSONArray(SLOTS);
       } catch (JSONException ex) {
-        logger.debug("Exception while reading slots array" + ex.getMessage());
+        logger.debug("Exception while reading slots array", ex);
       }
       for (int i = 0; i < array.length(); i++) {
         try {
           JSONObject slotStr = array.getJSONObject(i);
           slots.add(CdbResponseSlot.fromJson(slotStr));
         } catch (Exception ex) {
-          logger.debug("Exception while reading slot from slots array" + ex.getMessage());
+          logger.debug("Exception while reading slot from slots array", ex);
         }
       }
     }
 
-    return new CdbResponse(slots, timeToNextCall);
+    boolean consentGiven = false;
+    if (json.has(CONSENT_GIVEN)) {
+      try {
+        consentGiven = json.getBoolean(CONSENT_GIVEN);
+      } catch (JSONException ex) {
+        logger.debug("Exception while reading consentGiven", ex);
+      }
+    }
+
+    return new CdbResponse(slots, timeToNextCall, consentGiven);
   }
 
   @NonNull
@@ -87,6 +101,8 @@ public class CdbResponse {
   public int getTimeToNextCall() {
     return timeToNextCall;
   }
+
+  public boolean getConsentGiven() { return consentGiven; }
 
   @Nullable
   public CdbResponseSlot getSlotByImpressionId(@NonNull String impressionId) {
@@ -104,6 +120,7 @@ public class CdbResponse {
     return "CdbResponse{" +
         "slots=" + slots +
         ", timeToNextCall=" + timeToNextCall +
+        ", consentGiven = " + consentGiven +
         '}';
   }
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/privacy/ConsentData.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/privacy/ConsentData.kt
@@ -1,0 +1,43 @@
+/*
+ *    Copyright 2020 Criteo
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.criteo.publisher.privacy
+
+import com.criteo.publisher.annotation.OpenForTesting
+import java.util.concurrent.atomic.AtomicReference
+
+@OpenForTesting
+class ConsentData {
+
+  /**
+   * Consent can be in any of the following two states:
+   *
+   * <ul>
+   *  <li> CONSENT_GIVEN: it is known that consent has been given by the user</li>
+   *  <li> CONSENT_NOT_GIVEN: it is known that consent has not been given by the user,
+   *  or isn't known yet.</li>
+   * </ul>
+   */
+  enum class ConsentStatus {
+    CONSENT_GIVEN,
+    CONSENT_NOT_GIVEN
+  }
+  private val valueRef = AtomicReference<ConsentStatus>(ConsentStatus.CONSENT_NOT_GIVEN)
+
+  var consentStatus: ConsentStatus
+    get() = valueRef.get()
+    set(value) = valueRef.set(value)
+}

--- a/publisher-sdk/src/test/java/com/criteo/publisher/LiveCdbCallListenerTests.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/LiveCdbCallListenerTests.kt
@@ -21,6 +21,7 @@ import com.criteo.publisher.model.CacheAdUnit
 import com.criteo.publisher.model.CdbRequest
 import com.criteo.publisher.model.CdbResponse
 import com.criteo.publisher.model.CdbResponseSlot
+import com.criteo.publisher.privacy.ConsentData
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
@@ -44,6 +45,9 @@ class LiveCdbCallListenerTests {
 
   @Mock
   private lateinit var cacheAdUnit: CacheAdUnit
+
+  @Mock
+  private lateinit var consentData: ConsentData
 
   @InjectMocks
   private lateinit var liveCdbCallListener: LiveCdbCallListener
@@ -181,5 +185,23 @@ class LiveCdbCallListenerTests {
     verify(bidLifecycleListener).onCdbCallFailed(cdbRequest, exception)
     verify(bidLifecycleListener, never()).onBidConsumed(any(), any())
     verify(bidLifecycleListener).onCdbCallFailed(cdbRequest, exception)
+  }
+
+  @Test
+  fun onBidResponse_givenConsentGiven_ThenUpdateConsentDataAccordingly() {
+    whenever(cdbResponse.consentGiven).thenReturn(true)
+
+    liveCdbCallListener.onCdbResponse(cdbRequest, cdbResponse)
+
+    verify(consentData).consentStatus = ConsentData.ConsentStatus.CONSENT_GIVEN
+  }
+
+  @Test
+  fun onBidResponse_givenConsentNotGiven_ThenUpdateConsentDataAccordingly() {
+    whenever(cdbResponse.consentGiven).thenReturn(false)
+
+    liveCdbCallListener.onCdbResponse(cdbRequest, cdbResponse)
+
+    verify(consentData).consentStatus = ConsentData.ConsentStatus.CONSENT_NOT_GIVEN
   }
 }

--- a/publisher-sdk/src/test/java/com/criteo/publisher/model/CdbResponseTest.java
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/model/CdbResponseTest.java
@@ -106,7 +106,7 @@ public class CdbResponseTest {
 
   @Test
   public void getSlotByImpressionId_GivenEmptySlots_ReturnNull() throws Exception {
-    CdbResponse cdbResponse = new CdbResponse(emptyList(), 0);
+    CdbResponse cdbResponse = new CdbResponse(emptyList(), 0, false);
 
     assertThat(cdbResponse.getSlotByImpressionId("id")).isNull();
   }
@@ -121,7 +121,7 @@ public class CdbResponseTest {
     when(slot2.getImpressionId()).thenReturn(null);
     when(slot3.getImpressionId()).thenReturn("impId3");
 
-    CdbResponse cdbResponse = new CdbResponse(asList(slot1, slot2, slot3), 0);
+    CdbResponse cdbResponse = new CdbResponse(asList(slot1, slot2, slot3), 0, false);
 
     assertThat(cdbResponse.getSlotByImpressionId("id")).isNull();
   }
@@ -136,9 +136,25 @@ public class CdbResponseTest {
     when(slot2.getImpressionId()).thenReturn(null);
     when(slot3.getImpressionId()).thenReturn("id");
 
-    CdbResponse cdbResponse = new CdbResponse(asList(slot1, slot2, slot3), 0);
+    CdbResponse cdbResponse = new CdbResponse(asList(slot1, slot2, slot3), 0, false);
 
     assertThat(cdbResponse.getSlotByImpressionId("id")).isEqualTo(slot3);
+  }
+
+  @Test
+  public void fromJson_GivenConsentInfoTrue() throws Exception {
+    String json = "{\"slots\":[], \"consentGiven\": true}";
+    CdbResponse cdbResponse = CdbResponse.fromJson(new JSONObject(json));
+
+    assertThat(cdbResponse.getConsentGiven()).isTrue();
+  }
+
+  @Test
+  public void fromJson_GivenNoConsentInfoFalse() throws Exception {
+    String json = "{\"slots\":[], \"consentGiven\": false}";
+    CdbResponse cdbResponse = CdbResponse.fromJson(new JSONObject(json));
+
+    assertThat(cdbResponse.getConsentGiven()).isFalse();
   }
 
 }

--- a/test-utils/src/main/java/com/criteo/publisher/network/CdbMock.kt
+++ b/test-utils/src/main/java/com/criteo/publisher/network/CdbMock.kt
@@ -141,9 +141,11 @@ class CdbMock(private val jsonSerializer: JsonSerializer) {
 
       val responseSlots = cdbRequest.slots.mapNotNull { it.toResponseSlot() }.joinToString()
       val requestId = UUID.randomUUID().toString()
+
       val cdbResponse = """
       {
         "slots": [$responseSlots],
+        "consentGiven": "true",
         "requestId":"$requestId"
       }
     """.trimIndent()


### PR DESCRIPTION
The consent verification is made prior to sending metrics in the sending queue (in other words: what get puts into the sending queue, will be sent).

There are three states:
- CONSENT_GIVEN
- CONSENT_NOT_GIVEN
- CONSENT_UNKNOWN (when the response isn't retrieved from the backend yet).

When we are in the last state, we still write metrics. But, `CONSENT_GIVEN` is mandatory to send metrics to the sending queue.