### PR TITLE
Remove the synchronization in ConsentData

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/privacy/ConsentData.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/privacy/ConsentData.kt
@@ -25,10 +25,8 @@ class ConsentData(val sharedPreferences: SharedPreferences) {
     private const val CRITEO_CONSENT_GIVEN_KEY = "CRTO_ConsentGiven"
   }
 
-  @Synchronized
   fun isConsentGiven() = sharedPreferences.getBoolean(CRITEO_CONSENT_GIVEN_KEY, false)
 
-  @Synchronized
   fun setConsentGiven(consentGiven: Boolean) {
       val editor = sharedPreferences.edit()
       editor.putBoolean(CRITEO_CONSENT_GIVEN_KEY, consentGiven)


### PR DESCRIPTION
This will avoid unnecessary contention. `apply` is an atomic operation, but writing 
involves grabbing the reference to the `editor` first. Therefore, the only effect is that 
reading might not return the latest available value, but that is an acceptable trade-off.