### PR TITLE
Fix IT by moving consentGiven field in CDB mock response

### DIFF
--- a/test-utils/src/main/java/com/criteo/publisher/network/CdbMock.kt
+++ b/test-utils/src/main/java/com/criteo/publisher/network/CdbMock.kt
@@ -145,8 +145,8 @@ class CdbMock(private val jsonSerializer: JsonSerializer) {
       val cdbResponse = """
       {
         "slots": [$responseSlots],
-        "consentGiven": "true",
-        "requestId":"$requestId"
+        "requestId":"$requestId",
+        "consentGiven": "true"
       }
     """.trimIndent()
 


### PR DESCRIPTION
The integration tests are checking that CDB mock produce the same output
than the preprod. They are current failing because the tests are
comparing the raw results without knowing the format (JSON).