### PR TITLE
Fix IT by removing quotes around consentGiven value of CDB mock

### DIFF
--- a/test-utils/src/main/java/com/criteo/publisher/network/CdbMock.kt
+++ b/test-utils/src/main/java/com/criteo/publisher/network/CdbMock.kt
@@ -146,7 +146,7 @@ class CdbMock(private val jsonSerializer: JsonSerializer) {
       {
         "slots": [$responseSlots],
         "requestId":"$requestId",
-        "consentGiven": "true"
+        "consentGiven": true
       }
     """.trimIndent()
 


### PR DESCRIPTION
This was tested locally to avoid to do another fix commit.