### PR TITLE
Inject deviceId when missing in persisted log records

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/DependencyProvider.java
@@ -704,6 +704,7 @@ public class DependencyProvider {
         provideRemoteLogSendingQueue(),
         providePubSdkApi(),
         provideBuildConfigWrapper(),
+        provideAdvertisingInfo(),
         provideThreadPoolExecutor()
     ));
   }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogRecords.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogRecords.kt
@@ -30,10 +30,11 @@ data class RemoteLogRecords(
       @SerializedName("messages") val messages: List<String>
   )
 
+  @OpenForTesting
   data class RemoteLogContext(
       @SerializedName("version") val version: String,
       @SerializedName("bundleId") val bundleId: String,
-      @SerializedName("deviceId") val deviceId: String?,
+      @SerializedName("deviceId") var deviceId: String?,
       @SerializedName("sessionId") val sessionId: String,
       @SerializedName("profileId") val profileId: Int,
       @SerializedName("exception") val exceptionType: String?,

--- a/test-utils/src/main/java/com/criteo/publisher/csm/ConcurrentSendingQueueHelper.java
+++ b/test-utils/src/main/java/com/criteo/publisher/csm/ConcurrentSendingQueueHelper.java
@@ -16,10 +16,14 @@
 
 package com.criteo.publisher.csm;
 
+import static org.mockito.Mockito.mockingDetails;
+
 public class ConcurrentSendingQueueHelper {
 
   @SuppressWarnings("KotlinInternalInJava")
   public static void emptyQueue(ConcurrentSendingQueue<?> queue) {
-    queue.poll(Integer.MAX_VALUE);
+    if (!mockingDetails(queue).isMock() || mockingDetails(queue).isSpy()) {
+      queue.poll(Integer.MAX_VALUE);
+    }
   }
 }

--- a/test-utils/src/main/java/com/criteo/publisher/mock/MockedDependenciesRule.java
+++ b/test-utils/src/main/java/com/criteo/publisher/mock/MockedDependenciesRule.java
@@ -30,6 +30,7 @@ import com.criteo.publisher.DependencyProvider;
 import com.criteo.publisher.MockableDependencyProvider;
 import com.criteo.publisher.application.ApplicationResource;
 import com.criteo.publisher.concurrent.MultiThreadResource;
+import com.criteo.publisher.csm.ConcurrentSendingQueueHelper;
 import com.criteo.publisher.csm.MetricHelper;
 import com.criteo.publisher.logging.Logger;
 import com.criteo.publisher.logging.LoggerFactory;
@@ -270,6 +271,7 @@ public class MockedDependenciesRule implements MethodRule {
 
     // Clear CSM
     MetricHelper.cleanState(dependencyProvider);
+    ConcurrentSendingQueueHelper.emptyQueue(dependencyProvider.provideRemoteLogSendingQueue());
   }
 
   private void clearInternalState() {


### PR DESCRIPTION
Such situation might happen when the log record was created on the main
thread and that the deviceId was not ready yet: for instance for logs
emitted during initialization of the SDK.

The deviceId is assumed to be a constant. Hence, it is not an issue to
set it later. Although, this is quite a workaround based on an
assumption. Hence, the deviceId is kept if it is already set.

JIRA: EE-1411