### PR TITLE
Fix serialization of RemoteLogLevel

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/SafeRunnable.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/SafeRunnable.java
@@ -21,7 +21,7 @@ import static com.criteo.publisher.ErrorLogMessage.onUncaughtErrorInThread;
 import com.criteo.publisher.logging.Logger;
 import com.criteo.publisher.logging.LoggerFactory;
 import com.criteo.publisher.util.PreconditionsUtil;
-import java.io.IOException;
+import java.net.SocketException;
 import java.util.concurrent.ExecutionException;
 
 public abstract class SafeRunnable implements Runnable {
@@ -49,8 +49,8 @@ public abstract class SafeRunnable implements Runnable {
 
       if (throwable instanceof RuntimeException) {
         PreconditionsUtil.throwOrLog(e);
-      } else if (throwable instanceof IOException) {
-        // IO exceptions happen when network is slow/bad/unavailable or when disk is full/unavailable, ...
+      } else if (throwable instanceof SocketException) {
+        // Socket exceptions happen when network is slow/bad/unavailable, ...
         // Those are normal and expected situations. So they are not considered as errors.
         logger.debug(e);
       } else {

--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogRecords.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogRecords.kt
@@ -17,6 +17,7 @@
 package com.criteo.publisher.logging
 
 import android.util.Log
+import androidx.annotation.Keep
 import com.criteo.publisher.annotation.OpenForTesting
 import com.google.gson.annotations.SerializedName
 
@@ -41,6 +42,7 @@ data class RemoteLogRecords(
       @SerializedName("logId") val logId: String?
   )
 
+  @Keep // for serialization
   enum class RemoteLogLevel {
     @SerializedName("Debug")
     DEBUG,

--- a/publisher-sdk/src/test/java/com/criteo/publisher/SafeRunnableTest.kt
+++ b/publisher-sdk/src/test/java/com/criteo/publisher/SafeRunnableTest.kt
@@ -28,7 +28,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.Rule
 import org.junit.Test
-import java.io.IOException
+import java.net.SocketException
 
 class SafeRunnableTest {
     @Rule
@@ -65,10 +65,10 @@ class SafeRunnableTest {
     }
 
     @Test
-    fun givenIOException_LogItInDebug() {
+    fun givenSocketException_LogItInDebug() {
         doReturn(true).whenever(buildConfigWrapper).preconditionThrowsOnException()
 
-        val throwable = IOException()
+        val throwable = SocketException()
         val safeRunnable = createThrowingRunnable(throwable)
 
         assertThatCode { safeRunnable.run() }.doesNotThrowAnyException()


### PR DESCRIPTION
In release artifacts, the enum element was mangled, and even with the
`@SerializedName`, the GSON library still needs to access to enum values
by reflection.

JIRA: EE-1412