### PR TITLE
Explicitly use UTF-8 to write/read JSON

### DIFF
--- a/publisher-sdk/src/main/java/com/criteo/publisher/util/JsonSerializer.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/util/JsonSerializer.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
+import java.nio.charset.Charset;
 
 public class JsonSerializer {
 
@@ -53,7 +54,7 @@ public class JsonSerializer {
       @NonNull Object object,
       @NonNull OutputStream outputStream
   ) throws IOException {
-    OutputStreamWriter writer = new OutputStreamWriter(outputStream);
+    OutputStreamWriter writer = new OutputStreamWriter(outputStream, Charset.forName("UTF-8"));
 
     try {
       gson.toJson(object, writer);
@@ -82,7 +83,7 @@ public class JsonSerializer {
       @NonNull Class<T> expectedClass,
       @NonNull InputStream inputStream
   ) throws IOException {
-    Reader reader = new InputStreamReader(inputStream);
+    Reader reader = new InputStreamReader(inputStream, Charset.forName("UTF-8"));
 
     T object;
     try {


### PR DESCRIPTION
UTF-8 is generally the default encoding on Android. But it might not be
always the case. For instance, on Windows, the NativeProductTest is
failing without the explicit UTF-8 encoding.