### PR TITLE
Fix infinite loop of NoSuchMethodException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bug fixes
   - Reduce log level of network exception from error to info
   - Fix infinite `NoSuchMethodException` when Proguard is used with method inlining enabled
+  - Estimate size of in-memory queue and bound its size to avoid potential OOM
 
 # Version 4.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   - Removed support of Google SDK < v19.7.0 (see https://developers.google.com/admob/android/migration)
 - Features
   - Added support of Google SDK v20.0.0
+- Bug fixes
+  - Reduce log level of network exception from error to info
+  - Fix infinite `NoSuchMethodException` when Proguard is used with method inlining enabled
 
 # Version 4.2.2
 

--- a/publisher-sdk/build.gradle.kts
+++ b/publisher-sdk/build.gradle.kts
@@ -46,6 +46,7 @@ androidLibModule {
     addBuildConfigField<Int>("csmBatchSize")
     addBuildConfigField<Int>("maxSizeOfCsmMetricsFolder")
     addBuildConfigField<Int>("maxSizeOfCsmMetricSendingQueue")
+    addBuildConfigField<Int>("estimatedSizeOfCsmMetric")
 
     // Advanced Native
     addBuildConfigField<Int>("adChoiceIconWidthInDp")
@@ -55,6 +56,7 @@ androidLibModule {
     addBuildConfigField<Int>("remoteLogBatchSize")
     addBuildConfigField<String>("remoteLogQueueFilename")
     addBuildConfigField<Int>("maxSizeOfRemoteLogSendingQueue")
+    addBuildConfigField<Int>("estimatedSizeOfRemoteLog")
 
     // Misc
     addBuildConfigField<String>("pubSdkSharedPreferences")

--- a/publisher-sdk/config.groovy
+++ b/publisher-sdk/config.groovy
@@ -67,6 +67,7 @@ maxSizeOfCsmMetricsFolder = 48 * 1024
 
 // Maximum size (in bytes) of metric elements stored in the metric sending queue.
 // 60KB represents ~360 metrics (with ~170 bytes/metric) which already represent an extreme case.
+estimatedSizeOfCsmMetric = 170
 maxSizeOfCsmMetricSendingQueue = 60 * 1024
 
 /**
@@ -88,6 +89,7 @@ remoteLogQueueFilename = 'criteo_remote_logs_queue'
 
 // Maximum size (in bytes) of remote log elements stored in the sending queue.
 // 250KB represents ~51 logs (with ~5000 bytes/log with big stacktrace) which already represent an extreme case.
+estimatedSizeOfRemoteLog = 5000
 maxSizeOfRemoteLogSendingQueue = 250 * 1024
 
 environments {

--- a/publisher-sdk/consumer-proguard.txt
+++ b/publisher-sdk/consumer-proguard.txt
@@ -1,1 +1,10 @@
+# Used in DfpHeaderBiddingHandler
 -keep class com.google.android.gms.ads.** { *; }
+
+# Used in TapeSendingQueue
+-keepclassmembers class com.squareup.tape.QueueFile {
+  private int usedBytes();
+}
+-keepclassmembers class com.squareup.tape.FileObjectQueue {
+  private com.squareup.tape.QueueFile queueFile;
+}

--- a/publisher-sdk/src/main/java/com/criteo/publisher/csm/MetricSendingQueueConfiguration.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/csm/MetricSendingQueueConfiguration.kt
@@ -28,4 +28,6 @@ internal class MetricSendingQueueConfiguration(
   override val queueFilename: String
     get() = buildConfigWrapper.csmQueueFilename
   override val elementClass = Metric::class.java
+  override val estimatedSize: Int
+    get() = buildConfigWrapper.estimatedSizeOfCsmMetric
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/csm/SendingQueueConfiguration.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/csm/SendingQueueConfiguration.kt
@@ -32,4 +32,9 @@ internal interface SendingQueueConfiguration<T> {
    * Runtime class of the elements contained in the sending queue.
    */
   val elementClass: Class<T>
+
+  /**
+   * Estimated size in bytes of one element in the sending queue.
+   */
+  val estimatedSize: Int
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/csm/SendingQueueFactory.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/csm/SendingQueueFactory.java
@@ -38,7 +38,7 @@ public class SendingQueueFactory<T> implements Factory<ConcurrentSendingQueue<T>
   @NonNull
   @Override
   public ConcurrentSendingQueue<T> create() {
-    ConcurrentSendingQueue<T> tapeQueue = new TapeSendingQueue<>(objectQueueFactory);
+    ConcurrentSendingQueue<T> tapeQueue = new TapeSendingQueue<>(objectQueueFactory, sendingQueueConfiguration);
     return new BoundedSendingQueue<>(tapeQueue, sendingQueueConfiguration);
   }
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogSendingQueueConfiguration.kt
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/logging/RemoteLogSendingQueueConfiguration.kt
@@ -27,4 +27,6 @@ class RemoteLogSendingQueueConfiguration(
   override val queueFilename: String
     get() = buildConfigWrapper.remoteLogQueueFilename
   override val elementClass = RemoteLogRecords::class.java
+  override val estimatedSize: Int
+    get() = buildConfigWrapper.estimatedSizeOfRemoteLog
 }

--- a/publisher-sdk/src/main/java/com/criteo/publisher/util/BuildConfigWrapper.java
+++ b/publisher-sdk/src/main/java/com/criteo/publisher/util/BuildConfigWrapper.java
@@ -67,6 +67,13 @@ public class BuildConfigWrapper {
   }
 
   /**
+   * Estimated size (in bytes) of metric elements stored in the metric sending queue.
+   */
+  public int getEstimatedSizeOfCsmMetric() {
+    return BuildConfig.estimatedSizeOfCsmMetric;
+  }
+
+  /**
    * The relative path in application folder of the sending queue file for CSM
    */
   @NonNull
@@ -124,10 +131,17 @@ public class BuildConfigWrapper {
   }
 
   /**
-   * Maximum size (in bytes) of metric elements stored in the remote log sending queue.
+   * Maximum size (in bytes) of elements stored in the remote log sending queue.
    */
   public int getMaxSizeOfRemoteLogSendingQueue() {
     return BuildConfig.maxSizeOfRemoteLogSendingQueue;
+  }
+
+  /**
+   * Estimated size (in bytes) of elements stored in the remote log sending queue.
+   */
+  public int getEstimatedSizeOfRemoteLog() {
+    return BuildConfig.estimatedSizeOfRemoteLog;
   }
 
   /**


### PR DESCRIPTION
The `TapeSendingQueue` class accesses private members of a the
com.squareup.tape dependency:
- `FileObjectQueue#queueFile`
- `QueueFile#usedBytes()`

This privates members are used to determine the real size, in bytes, of
the queue. Then the queue can be capped to avoid consuming too much
memory (disk).

When using this SDK, publishers can apply minification. Since AGP 3.4.0,
R8 is enabled by default. Before Proguard was used. It is still possible
to used Proguard by applying `android.enableRB=false` in the
`gradle.properties`, but this option is deprecated since AGP 3.6.0.

With R8 minification, there is no error to signal.
With Proguard minification and optimization enabled, it is possible to
produce an infinite loop of `NoSuchMethodException` logs.

The explanation is that, with the default Android optimization rules
(proguard-android-optimize.txt), both `method/inlining/short` and
`method/inlining/unique` optimization rules are enabled. (see
https://www.guardsquare.com/en/products/proguard/manual/usage/optimizations).
Such optimization can inline methods at compile time rather than at
runtime via a JIT.

Now, as the `QueueFile#usedBytes()` is private and only used by another
method, it is inlined by Proguard. Hence the `NoSuchMethodException`
when trying to reach it.

The infinite loop of exception comes from the fact that the remote
logger use the `TapeSendingQueue` as a buffer. The exception is thrown
every time, it is logged, given to the remote logger, which use again
the `TapeSendingQueue`, ... indefinitely.

The `NoSuchMethodException` is fixed by indicating to Proguard to keep
elements reached by reflection. The infinite loop is therefore fixed
too, but a security is added to prevent infinite loop on worker threads.

JIRA: DPP-3238