### PR TITLE
📇 Updated developer email address to use one decoupled from Criteo in…

### DIFF
--- a/buildSrc/src/main/java/Publications.kt
+++ b/buildSrc/src/main/java/Publications.kt
@@ -123,7 +123,7 @@ class SdkPublication(
         // We rely on Git to recognize contributors
         developer {
           name.set("R&D Direct")
-          email.set("rnd-direct@criteo.com")
+          email.set("pubsdk-owner@criteo.com")
           organization.set("Criteo")
           organizationUrl.set("https://www.criteo.com/")
         }


### PR DESCRIPTION
[rnd-direct@criteo.com](mailto:rnd-direct@criteo.com) will disapear. Instead of using the new team ML, we should use a static component oriented ML and use ML ownership in Office365 to associate it to the proper org team.