### PR TITLE
🔧 Use only google_apis emulators for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
           include:
             - api: '30'
               abi: 'x86'
-              tag: 'playstore' # Explicitly need the PlayStore to fetch GAID
+              tag: 'google_apis'
 
             - api: '31'
               abi: 'x86_64'


### PR DESCRIPTION
Playstore emulators are more flaky than google_apis ones